### PR TITLE
feat: add batch Blueprint-to-C++ commandlet

### DIFF
--- a/Content/NodeToCode_Refs/N2C_EventStyleGuide.cpp
+++ b/Content/NodeToCode_Refs/N2C_EventStyleGuide.cpp
@@ -1,0 +1,30 @@
+// Example file implementation: Reference context for Node to Code, not included in compilation
+// Purpose: Demonstrate splitting Blueprint events into separate C++ methods
+
+#include "N2C_EventStyleGuide.h"
+
+// Override engine event BeginPlay, call Super::BeginPlay()
+void AN2C_EventStyleGuideActor::BeginPlay()
+{
+    Super::BeginPlay();
+
+    // Example logic: Trigger event dispatcher once
+    InternalCounter = 1;
+    OnSomethingHappened.Broadcast(InternalCounter);
+}
+
+// Override engine event Tick, call Super::Tick(DeltaTime)
+void AN2C_EventStyleGuideActor::Tick(float DeltaTime)
+{
+    Super::Tick(DeltaTime);
+
+    // Example logic: Increment counter
+    InternalCounter += 1;
+}
+
+// Custom event implementation, maintain one-to-one correspondence with Blueprint "Custom Event"
+void AN2C_EventStyleGuideActor::MyCustomEvent()
+{
+    // Example logic: Broadcast event
+    OnSomethingHappened.Broadcast(InternalCounter);
+}

--- a/Content/NodeToCode_Refs/N2C_EventStyleGuide.h
+++ b/Content/NodeToCode_Refs/N2C_EventStyleGuide.h
@@ -1,0 +1,34 @@
+#pragma once
+
+// Example file: Reference context for Node to Code, not included in compilation
+// Purpose: Demonstrate to LLM the expected style of splitting events into separate C++ methods
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+
+// Event dispatcher example: Dynamic multicast delegate
+// Demonstrates how to declare an event dispatcher
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnSomethingHappened, int32, Count);
+
+// Demonstrates event splitting rules (overriding engine events + custom events)
+class AN2C_EventStyleGuideActor : public AActor
+{
+    GENERATED_BODY()
+
+public:
+    // Override engine events, must use override and call Super::
+    virtual void BeginPlay() override;
+    virtual void Tick(float DeltaTime) override;
+
+    // Custom events should be generated as Blueprint-callable UFUNCTIONs, do not merge multiple events into one function
+    UFUNCTION(BlueprintCallable, Category="N2C|Events")
+    void MyCustomEvent();
+
+    // Demonstrates event dispatcher declaration and usage
+    UPROPERTY(BlueprintAssignable, Category="N2C|Events")
+    FOnSomethingHappened OnSomethingHappened;
+
+private:
+    // Example data only
+    int32 InternalCounter = 0;
+};

--- a/Content/Prompting/CodeGen_CPP.md
+++ b/Content/Prompting/CodeGen_CPP.md
@@ -159,9 +159,188 @@
         - "enums": Optional array. Each enum object includes:
           - "name": The name of the enum
 
+        - "components": Optional array. Each component object includes:
+          - "ComponentName": The Blueprint variable name for the component.
+          - "ComponentClassName": The underlying component class name (e.g. StaticMeshComponent).
+          - "AttachParentName": Optional name of the parent component or root this component is attached to.
+          - "OverriddenProperties": Array of variable-like objects describing only those properties whose defaults were changed on this component in the Blueprint.
+
     </nodeToCodeJsonSpecification>
 
     <instructions>
+        ### Event Structure Preservation - STRICT ###
+        - Treat each Blueprint Event as a distinct C++ method. Do NOT merge multiple events into a single function.
+        - Engine events must be generated as **overrides** on the C++ class with proper signatures and Super calls:
+          - BeginPlay -> `virtual void BeginPlay() override;` and call `Super::BeginPlay();` in implementation.
+          - Tick -> `virtual void Tick(float DeltaTime) override;` and call `Super::Tick(DeltaTime);` in implementation.
+          - ConstructionScript -> `virtual void OnConstruction(const FTransform& Transform) override;` and call `Super::OnConstruction(Transform);` in implementation.
+        - Custom events must be generated as **Delegates** (not UFUNCTIONs) using DECLARE_DYNAMIC_MULTICAST_DELEGATE or DECLARE_DYNAMIC_DELEGATE macros, declared as UPROPERTY(BlueprintAssignable) or UPROPERTY(BlueprintCallable) with 1:1 parameter mapping from the event pins. Functions are Functions, Events are Delegates - do not confuse them.
+        - If a Blueprint function graph clearly overrides a parent-class virtual function, use the `override` keyword on the declaration.
+        - Otherwise, declare Blueprint functions as native UFUNCTIONs, e.g.: `UFUNCTION(BlueprintCallable, Category="Auto") void MyBlueprintFunction(...);`.
+        - Event Dispatchers must be generated using DECLARE_DYNAMIC_* macros and UPROPERTY(BlueprintAssignable), and invoked with .Broadcast(...).
+        - The header (.h) must contain method declarations per-event. The source (.cpp) must contain separate implementations per-event. Do NOT inline all logic into a single large function.
+        - If multiple events exist in the provided graphs, output multiple, separate functions and their bodies, preserving names and roles.
+        - Graphs of type "EventGraph" should orchestrate calls to the correct per-event functions instead of absorbing them into a monolithic function.
+        - **Do NOT** redefine the class skeleton (UCLASS / class declaration / ctor / dtor) inside EventGraph graphs. That belongs exclusively to the ClassItSelf graph.
+
+        ### Class Skeleton, Components, Constructor, and Destructor - STRICT ###
+        - For each distinct Blueprint class identified by `metadata.BlueprintClass` (e.g. `AMCMyObjectBase`), ensure that the generated code assumes a concrete Unreal C++ class exists or will be created with:
+          - A default constructor, used to initialize components and member variables.
+          - A virtual destructor when appropriate (e.g. subclasses of AActor/APawn/UObject), even if empty, to make extension safe.
+        - The **exclusive place** to emit the class skeleton for C++ is the graph whose `graph_type` is `ClassItSelf` for that Blueprint class:
+          - Treat the `ClassItSelf` translation as responsible for defining or extending the main C++ class for this Blueprint.
+          - Its `graphDeclaration` must contain a **full `UCLASS` + `class` declaration block** with member fields, not just free functions or free-standing UPROPERTY/UFUNCTION declarations.
+          - All UPROPERTY declarations for this Blueprint **must appear inside the class body** here, not as global or namespace-scope declarations.
+          - You MUST also project every entry in the top-level `components[]` array into this class skeleton:
+            - For each component in `components[]`, declare a `UPROPERTY(...)` member whose C++ type is the appropriate component pointer type (e.g. `USceneComponent*`, `UStaticMeshComponent*`, `UTextRenderComponent*`, etc.) and whose name matches the Blueprint `ComponentName`.
+            - These component members belong only to the `ClassItSelf` graph; do not redeclare them in other graphs.
+          - It must declare the class constructor and (when appropriate) virtual destructor.
+          - In the constructor implementation for `ClassItSelf` (in `graphImplementation`), you MUST:
+            - Call `CreateDefaultSubobject<...>(TEXT("ComponentName"))` for each component, assigning the result to the corresponding component member.
+            - Use `SetupAttachment` (or equivalent) to attach child components to their parents based on `AttachParentName` (falling back to `RootComponent` when necessary).
+            - Initialize any overridden component properties listed in `OverriddenProperties` using the most semantically appropriate APIs (e.g. `SetRelativeLocation`, `SetWorldScale3D`, or direct member assignment when no better API exists).
+          - **Do NOT** declare or initialize components (UPROPERTY members or `CreateDefaultSubobject` calls) in any non-`ClassItSelf` graphs. Component definition and construction belong exclusively to the `ClassItSelf` graph’s `.h/.cpp`.
+          - Minimal expected pattern (illustrative only):
+            - `UCLASS()`
+            - `class AMyBlueprintClass : public AActor`
+            - `{`
+            - `public:`
+            - `    UPROPERTY(...)
+            -      int32 SomeMember;`
+            - `
+            -    UPROPERTY(...)
+            - `
+            -    AMyBlueprintClass();`
+            - `    virtual ~AMyBlueprintClass() override; // when appropriate`
+            - `
+            -    // Event / function declarations may be forward-declared here or in the EventGraph graph;`
+            - `    // keep this graph focused on class structure and lifetime.`
+            - `};`
+          - Its `graphImplementation` must contain the constructor/destructor implementations and any class-level initialization logic (e.g., component creation and setup). It must **not** contain full EventGraph bodies; those belong in the EventGraph graph.
+        - When the user provides reference .h/.cpp files, integrate with the existing class instead of inventing a new one:
+          - Add missing constructor/declaration if it does not already exist.
+          - Add missing destructor declaration/implementation if appropriate.
+          - Add new method declarations into the existing class body.
+        - When the user does *not* provide source files, generate a plausible full class skeleton in `graphDeclaration` for the primary Blueprint class, including:
+          - `UCLASS()` macro.
+          - Class declaration inheriting from the implied base (e.g. `AActor`).
+          - Constructor and destructor declarations.
+          - UPROPERTY members for variables and components.
+          - UFUNCTION declarations for all graph-based functions and events.
+
+        ### Variable Declaration Synthesis - STRICT ###
+        - Infer class-scope properties from Blueprint variable usage (e.g., VariableGet/VariableSet nodes, pins marked as Target/Member, or persistent state implied by flows).
+        - Declare such properties in the header (.h) with appropriate Unreal specifiers. Prefer:
+          - UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Auto") for commonly edited Blueprint variables.
+          - Use exact types derived from pin `type`/`sub_type`. For UObject-derived types, use pointers (e.g., AActor*). For structs/enums, use their native types.
+          - For container pins (is_array/is_map/is_set), generate TArray/ TMap/ TSet with correct value/key types.
+        - If type information is incomplete, emit a best-effort type plus a TODO comment explaining the assumption. Do NOT omit variable declarations.
+        - Ensure variable names mirror the Blueprint variable names when present; otherwise produce readable camel-case names derived from node/member names.
+
+        ### Component Synthesis from `components[]` - STRICT ###
+        - The root JSON may contain a `components[]` array describing Blueprint component instances whose default properties were overridden.
+        - For each entry in `components[]`:
+          - `ComponentName`: The Blueprint variable name of the component (e.g. "Root", "LockText", "HoverLight").
+          - `ComponentClassName`: The underlying component class (e.g. "SceneComponent", "StaticMeshComponent", "TextRenderComponent").
+          - `AttachParentName`: Optional parent component/root name. (May be empty in some engine versions.)
+          - `OverriddenProperties[]`: Variable-like objects describing only those properties whose defaults were changed on this component.
+
+        #### 1. Header (.h) component members
+        - For every `components[i]`, declare a corresponding UPROPERTY member on the owning class:
+          - Map `ComponentClassName` to the appropriate Unreal type:
+            - "SceneComponent" or similar -> `USceneComponent*` (or a more specific subclass when obvious).
+            - "StaticMeshComponent" -> `UStaticMeshComponent*`.
+            - "TextRenderComponent" -> `UTextRenderComponent*`.
+          - Use the `ComponentName` as the C++ member name (e.g. `LockText`, `HoverLight`).
+          - Prefer:
+            - `UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Components")` for these subobject members.
+
+        #### 2. Constructor (.cpp) component creation
+        - In the class constructor, create each component using `CreateDefaultSubobject` with the same name as `ComponentName`:
+          - Example pattern matching common Unreal style:
+            - Root (scene) component:
+              - `Root = CreateDefaultSubobject<USceneComponent>(TEXT("Root"));`
+              - `RootComponent = Root;`
+            - Child components:
+              - `LockText = CreateDefaultSubobject<UTextRenderComponent>(TEXT("LockText"));`
+              - `LockText->SetupAttachment(RootComponent);`
+        - When `AttachParentName` is non-empty and you can resolve a matching member, attach to that component:
+          - `SomeComp->SetupAttachment(ParentComp); // ParentComp name inferred from AttachParentName`
+        - When `AttachParentName` is empty or cannot be resolved:
+          - Attach non-root components to `RootComponent` (or whichever root-like scene component you declared) as a safe default.
+
+        #### 3. Applying overridden default values
+        - For each entry in `components[i].OverriddenProperties[]`:
+          - Use its `Name`, `Type`, `TypeName`, and `DefaultValue` to emit best-effort initialization code on that component instance.
+          - Examples:
+            - Text/strings on a `UTextRenderComponent`:
+              - `LockText->SetText(FText::FromString("Locked"));`
+            - Numeric/struct properties like world size, vectors, rotators, transforms:
+              - `LockText->SetWorldSize(30.f);`
+              - `HoverLight->SetRelativeLocation(FVector(...));`
+            - Booleans such as visibility or physics:
+              - `HoverLight->SetVisibility(false);`
+              - `Plane->SetSimulatePhysics(true);`
+        - IMPORTANT:
+          - Only assign properties that appear in `OverriddenProperties[]`. Do NOT attempt to re-emit all defaults from the engine CDO.
+          - Prefer using the component's native setter functions when they are obvious (`SetText`, `SetWorldSize`, `SetVisibility`, etc.). When unclear, assign directly to the property (e.g. `Component->bSomeFlag = true;`).
+
+        ### Blueprint Variables Mapping ###
+        - The N2C JSON provides variables at two different scopes:
+          - `variables[]` on the root FN2CBlueprint: **class member variables**.
+          - `graphs[].LocalVariables[]` on each FN2CGraph: **function-local variables** for that specific graph.
+        - Treat these as follows:
+          - Use `variables[]` to build a single, coherent member-variable section on the generated C++ class:
+            - Do NOT generate separate header/source files per variable.
+            - Emit one unified block of UPROPERTY fields (and any required initialization) that represents all Blueprint member variables.
+          - Use `graphs[i].LocalVariables[]` to build the local variable declarations for that graph/function:
+            - Declare these locals once, near the top of the generated function body, before they are first used.
+            - Use `Type`/`TypeName` and container flags to choose the C++ type.
+            - Use `DefaultValue` as a best-effort initialization for these locals when it is safe and reasonable.
+          - Never implicitly use identifiers that are not declared in:
+            - The function parameter list,
+            - `graphs[i].LocalVariables[]`, or
+            - `variables[]` (class members).
+
+        ### UPROPERTY Specifiers Mapping - STRICT ###
+        - Choose UPROPERTY specifiers based on usage semantics inferred from Blueprint:
+          - EditAnywhere vs EditDefaultsOnly: If variables are commonly adjusted in editor across instances, use EditAnywhere; otherwise EditDefaultsOnly.
+          - BlueprintReadWrite vs BlueprintReadOnly: If Blueprint both reads and writes, use BlueprintReadWrite; if read-only from BP perspective, use BlueprintReadOnly.
+          - VisibleAnywhere: For runtime-only fields set by code and not intended to be edited in editor.
+          - Transient: For ephemeral state (e.g., DoOnce gates, runtime caches) that should not be serialized.
+          - SaveGame: If persistence across sessions is implied (e.g., user progress/state), add SaveGame.
+          - Category: Use a stable default like "Auto" unless a clear category is derivable from context.
+        - Use meta tags when helpful (e.g., ClampMin/ClampMax for numeric ranges inferred from pins/defaults).
+        - Prefer forward declarations for UObjects in headers and include headers in .cpp to minimize compile dependencies.
+
+        ### Includes and External References - STRICT ###
+        - At the top of `graphImplementation`, emit necessary C++ `#include` lines for engine/framework symbols you directly use when headers are known; otherwise prefer forward declarations for UCLASS types to keep compile stable.
+        - For referenced Blueprints or assets with known paths, also emit pseudo-include comments to preserve reference context, e.g.:
+          - // include: /Game/Path/To/SomeAsset.SomeAsset_C
+        - For unknown header locations of engine/helper functions, add a conservative comment placeholder to guide integration, e.g.:
+          - // include: <KismetSystemLibrary> (resolve exact header if needed)
+        - Keep all pseudo-include comments grouped in a single block at the top of the implementation to aid later manual resolution.
+
+        ### Networking & Replication - STRICT ###
+        - Replicated Properties:
+          - For variables inferred to need network sync, declare with `UPROPERTY(Replicated)` or `UPROPERTY(ReplicatedUsing=OnRep_VarName)` in `.h`.
+          - Generate matching `void OnRep_VarName();` and implement it in `.cpp` when `ReplicatedUsing` is used.
+          - In the owning class constructor, ensure `bReplicates = true;` or `SetIsReplicatedByDefault(true);` as appropriate.
+          - Implement `void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;` in `.h` and define in `.cpp` using `DOREPLIFETIME(ThisClass, VarName);` for each replicated property. Include `#include "Net/UnrealNetwork.h"` in `.cpp`.
+        - RPC Functions:
+          - Generate RPCs based on Blueprint semantics:
+            - Server calls: `UFUNCTION(Server, Reliable)` or `(Server, Unreliable)` as inferred; name them `Server_...` by convention.
+            - Client calls: `UFUNCTION(Client, Reliable)` / `(Client, Unreliable)`; name them `Client_...`.
+            - Multicast: `UFUNCTION(NetMulticast, Reliable)` / `(Unreliable)`; name them `Multicast_...`.
+          - Implement authority guards where relevant:
+            - On server-required logic use `if (!HasAuthority()) { return; }` or `if (GetLocalRole() != ROLE_Authority) { return; }`.
+            - For client-only code use `IsLocallyControlled()` or `IsNetMode(NM_Client)` when appropriate.
+        - Replication Conditions and Meta:
+          - When context implies conditional replication, prefer `DOREPLIFETIME_CONDITION` and note the condition in `implementationNotes` if uncertain.
+        - Includes and Pseudo-Includes for Networking:
+          - Ensure `.cpp` has `#include "Net/UnrealNetwork.h"` when any replication or DOREPLIFETIME is emitted.
+          - Group networking-related pseudo-includes with other pseudo-includes at the top block.
+
         We assume that the user is only ever providing a snippet of Blueprint logic that may include one or more graphs and optionally references to structs or enums. You must convert the **Node to Code** JSON blueprint logic into corresponding function(s) in Unreal C++ code, using native Unreal Engine C++ functions, classes, and APIs wherever possible.
 
         ### Steps to Implement
@@ -296,8 +475,12 @@
 
         **Field Requirements**:
 
-        1. **graph_name**: The name of the graph, function, struct, or enum (taken from the N2C JSON’s fields).
-        2. **graph_type**: A string reflecting the type ("Function", "EventGraph", "Composite", "Macro", "Construction", "Struct", or "Enum").
+        1. **graph_name**: The name of the graph, function, struct, or enum.
+           - You MUST preserve the original Blueprint graph name from the input N2C JSON.
+           - Do NOT rename graphs in your output (e.g., do NOT change an `EventGraph` to the Blueprint class name, or invent new names).
+           - The `graph_name` value in the response must be exactly equal (string match) to the source graph’s name.
+           - For every input graph object in the top-level `graphs[]` array of the N2C JSON, you MUST emit exactly one corresponding output graph object whose `graph_name` is identical to that input graph’s `name` field. Do not merge multiple input graphs into a single output graph, and do not omit or invent graphs.
+        2. **graph_type**: A string reflecting the type ("Function", "EventGraph", "Composite", "Macro", "Construction", "ClassItSelf", "Struct", or "Enum").
         3. **graph_class**: Name of the class this graph is associated with (often from "metadata.BlueprintClass"), or an empty string if not applicable.
         4. **code**: An object holding three string fields:
            - "graphDeclaration": 

--- a/Content/README_N2C_Config.md
+++ b/Content/README_N2C_Config.md
@@ -1,0 +1,189 @@
+# NodeToCode 配置层优化变更说明
+
+本文件记录针对 NodeToCode 生成结果进行的“配置层”优化，以实现：
+1) 蓝图事件拆分为独立 C++ 方法，而非汇总到单一大函数；
+2) 自动生成类成员变量声明（含 UPROPERTY 修饰符）；
+3) 输出必要的 `#include` 与蓝图/资产的伪 include 注释。
+
+## 变更内容
+- 编辑 Prompt：`Plugins/NodeToCode/Content/Prompting/CodeGen_CPP.md`
+  - 新增章节：`Event Structure Preservation - STRICT`
+    - 每个蓝图事件对应独立 C++ 方法，禁止合并为单一大函数。
+    - 引擎事件以 `override` 形式生成并调用 `Super::`。
+    - 自定义事件以 `UFUNCTION(BlueprintCallable)` 形式生成，参数与引脚一一对应。
+    - 事件分发器使用 `DECLARE_DYNAMIC_*` 与 `UPROPERTY(BlueprintAssignable)`，通过 `.Broadcast(...)` 触发。
+    - `.h` 与 `.cpp` 分别生成声明与实现。
+  - 新增章节：`Variable Declaration Synthesis - STRICT`
+    - 基于 Blueprint 使用自动推断并在 `.h` 中生成 `UPROPERTY(...)` 成员（精确类型、容器、TODO 注释）。
+  - 新增章节：`UPROPERTY Specifiers Mapping - STRICT`
+    - 基于使用语义选择 `EditAnywhere/VisibleAnywhere/BlueprintReadWrite/Transient/SaveGame` 等修饰符与 `meta` 标签。
+  - 新增章节：`Includes and External References - STRICT`
+    - 在实现顶部输出必要 `#include`；为蓝图/资产输出 `// include: /Game/...` 伪包含注释；未知头文件输出占位注释。
+  - 新增章节：`Networking & Replication - STRICT`
+    - 变量：`UPROPERTY(Replicated)` / `UPROPERTY(ReplicatedUsing=OnRep_Var)` 与 `OnRep_Var()` 生成；构造函数 `SetIsReplicatedByDefault(true)`。
+    - 生命周期：声明并实现 `GetLifetimeReplicatedProps(...)`，在 `.cpp` 使用 `DOREPLIFETIME(ThisClass, Var)`；包含 `#include "Net/UnrealNetwork.h"`。
+    - RPC：按语义生成 `UFUNCTION(Server|Client|NetMulticast, Reliable|Unreliable)`，并在实现中添加必要的权限校验（如 `HasAuthority()`）。
+
+- 新增参考源文件（仅用于 LLM 参考上下文，不参与编译）：
+  - `Plugins/NodeToCode/Content/NodeToCode_Refs/N2C_EventStyleGuide.h`
+  - `Plugins/NodeToCode/Content/NodeToCode_Refs/N2C_EventStyleGuide.cpp`
+
+## 使用步骤
+1. 在 Project Settings → Plugins → Node to Code 中：
+   - 将 `Target Language` 设为 `C++`
+   - 将 `Max Translation Depth`（TranslationDepth）调至 `1` 或 `2`
+   - 根据偏好选择 Provider/Model（建议：Anthropic Sonnet 或 OpenAI o4-mini）
+   - 在 `Reference Source Files` 中添加：
+     - `Plugins/NodeToCode/Content/NodeToCode_Refs/N2C_EventStyleGuide.h`
+     - `Plugins/NodeToCode/Content/NodeToCode_Refs/N2C_EventStyleGuide.cpp`
+
+2. 重新执行翻译，并在输出目录（默认 `Saved/NodeToCode/Translations` 或自定义目录）对比结果结构。
+
+## 期望效果
+- 多个蓝图事件将被转换为多个独立的 C++ 方法（引擎事件 `BeginPlay`/`Tick` 等为 `override`，自定义事件为 `UFUNCTION`）。
+- 事件分发器将正确以动态多播代理形式生成与触发。
+- 带网络语义的变量与调用会自动输出：`Replicated/ReplicatedUsing`、`OnRep_`、`GetLifetimeReplicatedProps`（含 `DOREPLIFETIME`）、必要的 `#include "Net/UnrealNetwork.h"`，以及 Server/Client/Multicast RPC 声明与实现骨架。
+- Blueprint 成员变量会在模型输入中以集中列表的形式提供，便于在同一个 `.h`/`.cpp` 片段中统一生成变量声明，而不是为每个变量拆散成多个脚本片段。
+- 函数局部变量现在也会被包含在模型中，以确保正确的声明和默认值。
+
+## Translate Entire Blueprint 行为说明
+
+- 使用工具栏上的 `Translate Entire Blueprint` 时，现在会按「图」拆分为多次请求：
+  - 事件图、每个函数图、每个宏图分别序列化为独立的 N2C JSON。
+  - 每个 JSON 单独发送给 LLM 服务，降低单次请求的上下文长度，避免触发 DeepSeek/OpenAI 等 Provider 的最大上下文限制错误。
+- 输出落盘行为调整为“同一批次集中在一个时间戳目录下”：
+  - 每次执行 `Translate Entire Blueprint` 会为当前 Blueprint 生成一个带时间戳的根目录（例如 `Saved/NodeToCode/Translations/MyBP_2025-11-23-16.30.00/`）。
+  - 这一轮批次内的所有图（事件图/函数图/宏图）翻译结果都会写入该目录下的子文件夹中（按图名划分子目录），便于统一查看和管理。
+ - C++ 生成时的文件命名规则：
+   - 每个图依然有自己的子目录：`<时间戳根目录>/<GraphName>/`。
+   - 但当目标语言为 C++ 且图类型为 `EventGraph` 时，会使用 Blueprint 类名（`GraphClass`/`metadata.BlueprintClass`）作为 `.h/.cpp` 文件名：
+     - 例如：`AMyActor.h` / `AMyActor.cpp`，其中会集中放置：类声明、UPROPERTY 成员、组件声明与构造、构造函数/析构函数等。
+   - 其他图（函数图/宏图等）仍旧以图名作为文件前缀，保持原有拆分粒度不变。
+
+## Blueprint 组件（Components）默认值覆盖
+
+- 从现在开始，N2C JSON 顶层会额外包含一个 `components[]` 数组，用于描述当前 Blueprint 中挂载的组件实例，以及**相对于组件类默认值被修改过的属性**：
+  - `ComponentName`：该组件在 Blueprint 中的变量名（例如 `MyMesh`）。
+  - `ComponentClassName`：组件的类名（例如 `StaticMeshComponent`）。
+  - `AttachParentName`：可选，挂载到的父组件/根（例如 `RootComponent` 或某个 SceneComponent 名）。
+  - `OverriddenProperties[]`：只包含那些**被蓝图修改过**的属性，结构与 `variables[]` 类似（`Name / Type / TypeName / DefaultValue` 等）。
+- 生成 C++ 时，LLM 会参考 `components[]`：
+  - 在构造函数中使用 `CreateDefaultSubobject` 创建对应组件，并按 `AttachParentName` 做 `SetupAttachment`；
+  - 对每个组件仅对 `OverriddenProperties[]` 中出现的属性生成赋值代码（例如位置、旋转、布尔开关等），不会尝试覆盖所有引擎默认值；
+  - 这样可以在保持上下文体积可控的前提下，尽量复现 Blueprint 中对组件默认参数的修改。
+
+## C++ 生成约定补充（构造函数 / 析构函数 / override）
+
+- 在 CodeGen 的 Prompt 中，新增了针对 C++ 类骨架的强约束：
+  - 对于每个 Blueprint Class（例如 `AMCMagicCardBase`），要求 LLM 在生成 C++ 时：
+    - 为该类补全/生成默认构造函数，用于创建组件（`CreateDefaultSubobject`）并初始化成员变量；
+    - 在合适的情况下生成虚析构函数，保证继承链安全；
+    - 对于引擎事件（`BeginPlay` / `Tick` / `OnConstruction` 等），使用 `override` 关键字声明，并在实现中调用 `Super::Xxx(...)`；
+    - 对 Blueprint 自定义函数，使用 `UFUNCTION(BlueprintCallable, Category="Auto")` 等 native 方式声明，必要时在重写父类虚函数时同样加上 `override`。
+- 当用户提供已有的 .h/.cpp 文件时，LLM 会按 Prompt 要求将这些声明/实现**合并进现有类**，而不是重新定义一个重复的类。
+
+## 备注
+- `Reference Source Files` 的示例文件仅用于提示 LLM 遵循风格，不会影响项目编译逻辑。
+- 如果已有你自己的事件风格示例，建议优先加入你自己的 .h/.cpp 作为参考上下文。
+
+## C++ 生成增强方案与设计说明（对社区贡献摘要）
+
+本节用于向社区简要说明当前针对 Blueprint → C++ 的增强设计与实现状态，便于在开源仓库中讨论与演进。
+
+### 1. N2C JSON 模型扩展：components[]（已实现）
+
+- 在 `FN2CBlueprint` 顶层新增 `components[]` 数组，描述 Blueprint 中挂载的组件实例以及**相对于组件类默认值被修改过的属性**：
+  - `ComponentName`：组件在 Blueprint 中的变量名。
+  - `ComponentClassName`：组件类名（如 `StaticMeshComponent`、`TextRenderComponent` 等）。
+  - `AttachParentName`：可选，挂载到的父组件/根名称（某些版本可能为空）。
+  - `OverriddenProperties[]`：仅包含相对于对应组件类 CDO 被修改过的属性，结构沿用 `variables[]`（`Name / Type / TypeName / DefaultValue` 等）。
+- 在 `FN2CNodeTranslator::CollectComponentOverrides` 中：
+  - 遍历 Blueprint 的 `SimpleConstructionScript`，对每个 `USCS_Node` 的 `ComponentTemplate` 与类 CDO 做属性对比。
+  - 仅当某个属性相对 CDO 发生变更时，才将其写入 `OverriddenProperties[]`，从而控制上下文长度并聚焦“真正被修改过的默认值”。
+
+### 2. Prompt 侧 C++ 生成约束（已实现）
+
+对应文件：`Content/Prompting/CodeGen_CPP.md`。
+
+- **事件与函数结构（Event Structure Preservation - STRICT）**：
+  - 每个 Blueprint 事件转为独立 C++ 方法，禁止合并为单一大函数。
+  - 引擎事件统一以 `override` 形式声明并在实现中调用 `Super::Xxx(...)`。
+  - 自定义事件 / Blueprint 函数以 `UFUNCTION(BlueprintCallable, Category="Auto")` 等 native 风格声明。
+  - 事件分发器使用 `DECLARE_DYNAMIC_*` + `UPROPERTY(BlueprintAssignable)`，并通过 `.Broadcast(...)` 触发。
+  - `.h` 只放声明、`.cpp` 只放实现，保持 Unreal 代码风格。
+
+- **类骨架 / 构造 / 析构（Class Skeleton, Constructor, and Destructor - STRICT）**：
+  - 对每个 Blueprint 类（`metadata.BlueprintClass`），要求生成或补全对应的 C++ 类：
+    - 默认构造函数：用于创建组件并初始化成员变量。
+    - 适当的虚析构函数：保证继承链安全（AActor/APawn/UObject 子类）。
+  - 将 `graph_type == "EventGraph"` 对应的翻译视为**该 Blueprint 类的主 C++ 类骨架承载者**：
+    - 其 `graphDeclaration` 必须包含：
+      - `UCLASS()` 宏。
+      - `class <BlueprintClass> : public <BaseClass>` 声明。
+      - 成员字段，包括：
+        - 由顶层 `variables[]` 推断出的 UPROPERTY 成员。
+        - 由 `components[]` 推断出的组件 UPROPERTY 成员。
+      - 所有事件 / 函数的 UFUNCTION 声明。
+    - 其 `graphImplementation` 必须包含：
+      - 构造函数实现（组件 `CreateDefaultSubobject`、`SetupAttachment`、成员初始化）。
+      - 需要时的析构函数实现。
+      - 与类级别初始化相关的其它逻辑。
+  - 当用户提供参考 `.h/.cpp` 时：
+    - 不新建重复类，而是将上述声明/实现合并进既有类体和 `.cpp` 文件中，并补齐缺失的构造/析构/方法声明。
+
+- **变量与组件映射（Variable + Component Synthesis - STRICT）**：
+  - 顶层 `variables[]`：
+    - 视为类成员变量，在 `.h` 中生成统一的 UPROPERTY 成员区块，而不是为每个变量拆开多个脚本片段。
+  - `graphs[i].LocalVariables[]`：
+    - 视为函数局部变量，在 `graphImplementation` 中的函数体前部声明，并尽可能根据 `DefaultValue` 进行安全初始化。
+  - `components[]`：
+    - `.h` 中声明组件 UPROPERTY 成员（`USceneComponent*` / `UStaticMeshComponent*` / `UTextRenderComponent*` 等）。
+    - 构造函数中使用 `CreateDefaultSubobject` 创建组件并根据 `AttachParentName` 调用 `SetupAttachment`，必要时退化为挂到 `RootComponent`。
+    - 仅对 `OverriddenProperties[]` 中出现的属性生成赋值代码，优先使用语义化 `SetXxx` 接口，其次直接属性赋值。
+
+- **网络与包含（Networking & Includes）**：
+  - 根据语义推断自动生成：
+    - `UPROPERTY(Replicated)` / `UPROPERTY(ReplicatedUsing=OnRep_)`。
+    - `OnRep_` 函数及实现。
+    - `GetLifetimeReplicatedProps` + `DOREPLIFETIME(ThisClass, Var)`。
+    - RPC：`UFUNCTION(Server|Client|NetMulticast, Reliable|Unreliable)` + 权限检查逻辑。
+  - 保证 `.cpp` 包含 `#include "Net/UnrealNetwork.h"`，并在文件顶部集中输出伪 include 注释，便于后续人工补完头文件。
+
+### 3. 输出目录与 C++ 文件命名（已实现）
+
+- **批次根目录**：
+  - `Translate Entire Blueprint` 时，仍按图拆分为多个请求，每个图各自生成一份 N2C JSON。
+  - 同一轮请求的所有图共享一个带时间戳的根目录，例如：
+    - `Saved/NodeToCode/Translations/MyBP_2025-11-23-16.30.00/`。
+  - 从实现层面看，会先对整个 Blueprint 调用一次 `GenerateFromBlueprint` 生成完整的 `FN2CBlueprint`（包含所有图以及合成出来的 `ClassItSelf` 图），然后按图切片构造“每图一个 Blueprint 视图”的 N2C JSON 发送给 LLM，因此 ClassItSelf 也会参与整蓝图批量翻译流程。
+
+- **每个图的子目录与文件名**：
+  - 每个 graph 有自己的子目录：`<时间戳根目录>/<GraphName>/`，内部存放该图的 `.h/.cpp` 以及 `_Notes.txt` 等辅助文件。
+  - 实际写盘时会对 `GraphName` 做一次**轻量的文件名安全清洗**：
+    - 去掉首尾空格；
+    - 将 Windows 不支持的文件名字符（如 `< > : " / \\ | ? *` 等）替换为下划线 `_`；
+    - JSON 中的 `graph_name` 保持原样不变，仅文件系统路径使用清洗后的名字。
+  - 当前实现中，无论图类型（EventGraph/Function/Macro 等），生成的 C++ 文件均使用**清洗后的 `GraphName`** 作为文件名前缀：
+    - 例如：`EventGraph/EventGraph.h`、`SomeFunction/SomeFunction.cpp`。
+  - 对于 C++ 的 `ClassItSelf` 图（`graph_type == "ClassItSelf"`）且其 `graph_class` 非空时，除了按图输出 `ClassItSelf/ClassItSelf.*` 以外，还会额外生成一对以类名命名的脚本：
+    - `<时间戳根目录>/<GraphClass>/<GraphClass>.h`
+    - `<时间戳根目录>/<GraphClass>/<GraphClass>.cpp`
+  - 这两份类名脚本仅承载类骨架：
+    - UCLASS 与完整 class 声明；
+    - 所有 Blueprint 变量对应的 UPROPERTY 成员；
+    - 所有 Blueprint 组件（来自 `components[]`）对应的 UPROPERTY 组件指针成员；
+    - 构造/析构函数声明与实现；
+    - 在构造函数中通过 `CreateDefaultSubobject` 创建组件、根据 `AttachParentName` 调用 `SetupAttachment`、以及对 `OverriddenProperties[]` 中属性的初始化逻辑。
+  - 组件的 UPROPERTY 成员与构造阶段的创建/挂接/属性初始化**只会出现在 `<GraphClass>.h/.cpp` 这对类骨架文件中**，不会出现在 `EventGraph` 等其他按图拆分的 `.h/.cpp` 里；
+  - `EventGraph` 图本身只负责事件/函数的声明与实现，不再在类目录下生成额外副本，从而保持“类结构 + 组件 + 构造/析构”和“事件逻辑”在输出层面上的清晰分离。
+
+### 4. override/native 风格可配置化（规划中）
+
+- 目前 Prompt 中对事件与函数声明风格是“写死”的：
+  - 引擎事件统一使用 `override`。
+  - 自定义函数统一使用 `UFUNCTION(BlueprintCallable, Category="Auto")` 等 native 风格。
+- 计划在 `UN2CSettings` 中增加配置项（例如 `bUseNativeOverrideStyleForFunctions` 或 `EN2CFunctionStyle`），并在 Prompt 组装时读取：
+  - 开启：维持当前“强 native + override”风格。
+  - 关闭：使用更简化的函数声明风格，弱化 `override`/`UFUNCTION` 约束，方便某些项目做轻量级迁移。
+
+这一系列设计在不改变 NodeToCode 核心数据模型（`FN2CBlueprint`/`FN2CGraph`）的前提下，通过 Prompt 约定与落盘命名策略，将“类骨架 + 组件 + 构造/析构”聚合到以 Blueprint 类名命名的 C++ 脚本中，同时保留按图拆分的优势，便于后续社区在此基础上迭代。

--- a/Content/readmd.md
+++ b/Content/readmd.md
@@ -1,0 +1,1751 @@
+{
+		"version": "1.0.0",
+		"metadata":
+		{
+			"name": "BP_MCGameInstance",
+			"blueprint_type": "Normal",
+			"blueprint_class": "BP_MCGameInstance"
+		},
+		"graphs": [
+			{
+				"name": "EventGraph",
+				"graph_type": "EventGraph",
+				"nodes": [
+					{
+						"id": "N1",
+						"type": "CustomEvent",
+						"name": "CreateServer",
+						"member_name": "None",
+						"input_pins": [],
+						"output_pins": [
+							{
+								"id": "P1",
+								"name": "Output Delegate",
+								"type": "Delegate"
+							},
+							{
+								"id": "P2",
+								"name": "",
+								"connected": true
+							}
+						]
+					},
+					{
+						"id": "N3",
+						"type": "CallFunction",
+						"name": "Open Level (by Name)",
+						"member_parent": "GameplayStatics",
+						"member_name": "OpenLevel",
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P3",
+								"name": "Level Name",
+								"type": "Name",
+								"default_value": "None",
+								"connected": true
+							},
+							{
+								"id": "P4",
+								"name": "Absolute",
+								"type": "Boolean",
+								"default_value": "true"
+							},
+							{
+								"id": "P5",
+								"name": "Options",
+								"type": "String",
+								"default_value": "Listen"
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P2",
+								"name": "",
+								"connected": true
+							}
+						]
+					},
+					{
+						"id": "N5",
+						"type": "CallFunction",
+						"name": "Print String",
+						"member_parent": "KismetSystemLibrary",
+						"member_name": "PrintString",
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P3",
+								"name": "In String",
+								"type": "String",
+								"default_value": "Creating Game Session..."
+							},
+							{
+								"id": "P4",
+								"name": "Print to Screen",
+								"type": "Boolean",
+								"default_value": "true"
+							},
+							{
+								"id": "P5",
+								"name": "Print to Log",
+								"type": "Boolean",
+								"default_value": "true"
+							},
+							{
+								"id": "P6",
+								"name": "Text Color",
+								"type": "Struct",
+								"sub_type": "LinearColor",
+								"default_value": "(R=0.000000,G=1.000000,B=0.007393,A=1.000000)"
+							},
+							{
+								"id": "P7",
+								"name": "Duration",
+								"type": "Real",
+								"sub_type": "float",
+								"default_value": "10"
+							},
+							{
+								"id": "P8",
+								"name": "Key",
+								"type": "Name",
+								"default_value": "None",
+								"is_const": true
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P2",
+								"name": "",
+								"connected": true
+							}
+						]
+					},
+					{
+						"id": "N7",
+						"type": "CallFunction",
+						"name": "Print String",
+						"member_parent": "KismetSystemLibrary",
+						"member_name": "PrintString",
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P3",
+								"name": "In String",
+								"type": "String",
+								"default_value": "Failed to Create Game Session..."
+							},
+							{
+								"id": "P4",
+								"name": "Print to Screen",
+								"type": "Boolean",
+								"default_value": "true"
+							},
+							{
+								"id": "P5",
+								"name": "Print to Log",
+								"type": "Boolean",
+								"default_value": "true"
+							},
+							{
+								"id": "P6",
+								"name": "Text Color",
+								"type": "Struct",
+								"sub_type": "LinearColor",
+								"default_value": "(R=0.000000,G=1.000000,B=0.007393,A=1.000000)"
+							},
+							{
+								"id": "P7",
+								"name": "Duration",
+								"type": "Real",
+								"sub_type": "float",
+								"default_value": "10"
+							},
+							{
+								"id": "P8",
+								"name": "Key",
+								"type": "Name",
+								"default_value": "None",
+								"is_const": true
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P2",
+								"name": "",
+								"connected": true
+							}
+						]
+					},
+					{
+						"id": "N8",
+						"type": "CallFunction",
+						"name": "Get Player Controller",
+						"member_parent": "GameplayStatics",
+						"member_name": "GetPlayerController",
+						"pure": true,
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "Player Index",
+								"type": "Integer",
+								"default_value": "0"
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P2",
+								"name": "Return Value",
+								"type": "Object",
+								"sub_type": "PlayerController",
+								"connected": true
+							}
+						]
+					},
+					{
+						"id": "N9",
+						"type": "CustomEvent",
+						"name": "OpenMainMenu",
+						"member_name": "None",
+						"input_pins": [],
+						"output_pins": [
+							{
+								"id": "P1",
+								"name": "Output Delegate",
+								"type": "Delegate"
+							},
+							{
+								"id": "P2",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P3",
+								"name": "Actor",
+								"type": "Object",
+								"sub_type": "Actor",
+								"connected": true
+							}
+						]
+					},
+					{
+						"id": "N10",
+						"type": "MacroInstance",
+						"name": "Can Execute Cosmetic Events",
+						"member_parent": "StandardMacros",
+						"member_name": "Can Execute Cosmetic Events",
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "",
+								"connected": true
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P2",
+								"name": "True",
+								"connected": true
+							},
+							{
+								"id": "P3",
+								"name": "False"
+							}
+						]
+					},
+					{
+						"id": "N12",
+						"type": "CallFunction",
+						"name": "Get Player Controller",
+						"member_parent": "GameplayStatics",
+						"member_name": "GetPlayerController",
+						"pure": true,
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "Player Index",
+								"type": "Integer",
+								"default_value": "0"
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P2",
+								"name": "Return Value",
+								"type": "Object",
+								"sub_type": "PlayerController",
+								"connected": true
+							}
+						]
+					},
+					{
+						"id": "N13",
+						"type": "VariableSet",
+						"name": "bShowMouseCursor",
+						"member_parent": "bool",
+						"member_name": "bShowMouseCursor",
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P3",
+								"name": "Show Mouse Cursor",
+								"type": "Boolean",
+								"default_value": "true"
+							},
+							{
+								"id": "P5",
+								"name": "Target",
+								"type": "Object",
+								"sub_type": "PlayerController",
+								"connected": true
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P2",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P4",
+								"name": "",
+								"type": "Boolean",
+								"default_value": "false"
+							}
+						]
+					},
+					{
+						"id": "N15",
+						"type": "AsyncAction",
+						"name": "Join Session",
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P5",
+								"name": "Player Controller",
+								"type": "Object",
+								"sub_type": "PlayerController",
+								"connected": true
+							},
+							{
+								"id": "P6",
+								"name": "Search Result",
+								"type": "Struct",
+								"sub_type": "BlueprintSessionResult",
+								"connected": true,
+								"is_reference": true,
+								"is_const": true
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P2",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P3",
+								"name": "On Success",
+								"connected": true
+							},
+							{
+								"id": "P4",
+								"name": "On Failure",
+								"connected": true
+							}
+						]
+					},
+					{
+						"id": "N19",
+						"type": "CallFunction",
+						"name": "Print String",
+						"member_parent": "KismetSystemLibrary",
+						"member_name": "PrintString",
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P3",
+								"name": "In String",
+								"type": "String",
+								"default_value": "Joining Game Session..."
+							},
+							{
+								"id": "P4",
+								"name": "Print to Screen",
+								"type": "Boolean",
+								"default_value": "true"
+							},
+							{
+								"id": "P5",
+								"name": "Print to Log",
+								"type": "Boolean",
+								"default_value": "true"
+							},
+							{
+								"id": "P6",
+								"name": "Text Color",
+								"type": "Struct",
+								"sub_type": "LinearColor",
+								"default_value": "(R=0.000000,G=1.000000,B=0.007393,A=1.000000)"
+							},
+							{
+								"id": "P7",
+								"name": "Duration",
+								"type": "Real",
+								"sub_type": "float",
+								"default_value": "5"
+							},
+							{
+								"id": "P8",
+								"name": "Key",
+								"type": "Name",
+								"default_value": "None",
+								"is_const": true
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P2",
+								"name": ""
+							}
+						]
+					},
+					{
+						"id": "N17",
+						"type": "CallFunction",
+						"name": "Print String",
+						"member_parent": "KismetSystemLibrary",
+						"member_name": "PrintString",
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P3",
+								"name": "In String",
+								"type": "String",
+								"default_value": "Joined Game Session..."
+							},
+							{
+								"id": "P4",
+								"name": "Print to Screen",
+								"type": "Boolean",
+								"default_value": "true"
+							},
+							{
+								"id": "P5",
+								"name": "Print to Log",
+								"type": "Boolean",
+								"default_value": "true"
+							},
+							{
+								"id": "P6",
+								"name": "Text Color",
+								"type": "Struct",
+								"sub_type": "LinearColor",
+								"default_value": "(R=0.000000,G=1.000000,B=0.007393,A=1.000000)"
+							},
+							{
+								"id": "P7",
+								"name": "Duration",
+								"type": "Real",
+								"sub_type": "float",
+								"default_value": "5"
+							},
+							{
+								"id": "P8",
+								"name": "Key",
+								"type": "Name",
+								"default_value": "None",
+								"is_const": true
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P2",
+								"name": "",
+								"connected": true
+							}
+						]
+					},
+					{
+						"id": "N18",
+						"type": "CallFunction",
+						"name": "Print String",
+						"member_parent": "KismetSystemLibrary",
+						"member_name": "PrintString",
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P3",
+								"name": "In String",
+								"type": "String",
+								"default_value": "Failed to Join Game Session..."
+							},
+							{
+								"id": "P4",
+								"name": "Print to Screen",
+								"type": "Boolean",
+								"default_value": "true"
+							},
+							{
+								"id": "P5",
+								"name": "Print to Log",
+								"type": "Boolean",
+								"default_value": "true"
+							},
+							{
+								"id": "P6",
+								"name": "Text Color",
+								"type": "Struct",
+								"sub_type": "LinearColor",
+								"default_value": "(R=1.000000,G=0.000000,B=0.059079,A=1.000000)"
+							},
+							{
+								"id": "P7",
+								"name": "Duration",
+								"type": "Real",
+								"sub_type": "float",
+								"default_value": "5"
+							},
+							{
+								"id": "P8",
+								"name": "Key",
+								"type": "Name",
+								"default_value": "None",
+								"is_const": true
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P2",
+								"name": "",
+								"connected": true
+							}
+						]
+					},
+					{
+						"id": "N21",
+						"type": "CustomEvent",
+						"name": "Event_JoinGameSession",
+						"member_name": "None",
+						"input_pins": [],
+						"output_pins": [
+							{
+								"id": "P1",
+								"name": "Output Delegate",
+								"type": "Delegate"
+							},
+							{
+								"id": "P2",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P3",
+								"name": "Join Session",
+								"type": "Struct",
+								"sub_type": "BlueprintSessionResult",
+								"connected": true
+							}
+						]
+					},
+					{
+						"id": "N23",
+						"type": "CallFunction",
+						"name": "Get Player Controller",
+						"member_parent": "GameplayStatics",
+						"member_name": "GetPlayerController",
+						"pure": true,
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "Player Index",
+								"type": "Integer",
+								"default_value": "0"
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P2",
+								"name": "Return Value",
+								"type": "Object",
+								"sub_type": "PlayerController",
+								"connected": true
+							}
+						]
+					},
+					{
+						"id": "N14",
+						"type": "CallFunction",
+						"name": "Set View Target with Blend",
+						"member_parent": "PlayerController",
+						"member_name": "SetViewTargetWithBlend",
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P3",
+								"name": "Target",
+								"type": "Object",
+								"sub_type": "PlayerController",
+								"connected": true
+							},
+							{
+								"id": "P4",
+								"name": "New View Target",
+								"type": "Object",
+								"sub_type": "Actor",
+								"connected": true
+							},
+							{
+								"id": "P5",
+								"name": "Blend Time",
+								"type": "Real",
+								"sub_type": "float",
+								"default_value": "0.000000"
+							},
+							{
+								"id": "P6",
+								"name": "Blend Func",
+								"type": "Byte",
+								"sub_type": "EViewTargetBlendFunction",
+								"default_value": "VTBlend_Linear"
+							},
+							{
+								"id": "P7",
+								"name": "Blend Exp",
+								"type": "Real",
+								"sub_type": "float",
+								"default_value": "0.000000"
+							},
+							{
+								"id": "P8",
+								"name": "Lock Outgoing",
+								"type": "Boolean",
+								"default_value": "false"
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P2",
+								"name": "",
+								"connected": true
+							}
+						]
+					},
+					{
+						"id": "N24",
+						"type": "CallFunction",
+						"name": "Set Input Mode Game And UI",
+						"member_parent": "WidgetBlueprintLibrary",
+						"member_name": "SetInputMode_GameAndUIEx",
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P3",
+								"name": "Player Controller",
+								"type": "Object",
+								"sub_type": "PlayerController",
+								"connected": true
+							},
+							{
+								"id": "P4",
+								"name": "In Widget to Focus",
+								"type": "Object",
+								"sub_type": "Widget"
+							},
+							{
+								"id": "P5",
+								"name": "In Mouse Lock Mode",
+								"type": "Byte",
+								"sub_type": "EMouseLockMode",
+								"default_value": "DoNotLock"
+							},
+							{
+								"id": "P6",
+								"name": "Hide Cursor During Capture",
+								"type": "Boolean",
+								"default_value": "false"
+							},
+							{
+								"id": "P7",
+								"name": "Flush Input",
+								"type": "Boolean",
+								"default_value": "false",
+								"is_const": true
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P2",
+								"name": ""
+							}
+						]
+					},
+					{
+						"id": "N25",
+						"type": "AsyncAction",
+						"name": "Create Advanced Session",
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P5",
+								"name": "Extra Settings",
+								"type": "Struct",
+								"sub_type": "SessionPropertyKeyPair",
+								"is_reference": true,
+								"is_const": true,
+								"is_array": true
+							},
+							{
+								"id": "P6",
+								"name": "Player Controller",
+								"type": "Object",
+								"sub_type": "PlayerController",
+								"connected": true
+							},
+							{
+								"id": "P7",
+								"name": "Public Connections",
+								"type": "Integer",
+								"default_value": "100"
+							},
+							{
+								"id": "P8",
+								"name": "Private Connections",
+								"type": "Integer",
+								"default_value": "0"
+							},
+							{
+								"id": "P9",
+								"name": "Use LAN",
+								"type": "Boolean",
+								"default_value": "false"
+							},
+							{
+								"id": "P10",
+								"name": "Allow Invites",
+								"type": "Boolean",
+								"default_value": "true"
+							},
+							{
+								"id": "P11",
+								"name": "Is Dedicated Server",
+								"type": "Boolean",
+								"default_value": "false"
+							},
+							{
+								"id": "P12",
+								"name": "Use Presence",
+								"type": "Boolean",
+								"default_value": "true"
+							},
+							{
+								"id": "P13",
+								"name": "Use Lobbies if Available",
+								"type": "Boolean",
+								"default_value": "true"
+							},
+							{
+								"id": "P14",
+								"name": "Allow Join Via Presence",
+								"type": "Boolean",
+								"default_value": "true"
+							},
+							{
+								"id": "P15",
+								"name": "Allow Join Via Presence Friends Only",
+								"type": "Boolean",
+								"default_value": "false"
+							},
+							{
+								"id": "P16",
+								"name": "Anti Cheat Protected",
+								"type": "Boolean",
+								"default_value": "false"
+							},
+							{
+								"id": "P17",
+								"name": "Uses Stats",
+								"type": "Boolean",
+								"default_value": "false"
+							},
+							{
+								"id": "P18",
+								"name": "Should Advertise",
+								"type": "Boolean",
+								"default_value": "true"
+							},
+							{
+								"id": "P19",
+								"name": "Use Lobbies Voice Chat if Available",
+								"type": "Boolean",
+								"default_value": "false"
+							},
+							{
+								"id": "P20",
+								"name": "Start After Create",
+								"type": "Boolean",
+								"default_value": "true"
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P2",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P3",
+								"name": "On Success",
+								"connected": true
+							},
+							{
+								"id": "P4",
+								"name": "On Failure",
+								"connected": true
+							}
+						]
+					},
+					{
+						"id": "N27",
+						"type": "AsyncAction",
+						"name": "Destroy Session",
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P5",
+								"name": "Player Controller",
+								"type": "Object",
+								"sub_type": "PlayerController",
+								"connected": true
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P2",
+								"name": ""
+							},
+							{
+								"id": "P3",
+								"name": "On Success",
+								"connected": true
+							},
+							{
+								"id": "P4",
+								"name": "On Failure",
+								"connected": true
+							}
+						]
+					},
+					{
+						"id": "N29",
+						"type": "CallFunction",
+						"name": "Get Player Controller",
+						"member_parent": "GameplayStatics",
+						"member_name": "GetPlayerController",
+						"pure": true,
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "Player Index",
+								"type": "Integer",
+								"default_value": "0"
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P2",
+								"name": "Return Value",
+								"type": "Object",
+								"sub_type": "PlayerController",
+								"connected": true
+							}
+						]
+					},
+					{
+						"id": "N30",
+						"type": "AsyncAction",
+						"name": "Destroy Session",
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P5",
+								"name": "Player Controller",
+								"type": "Object",
+								"sub_type": "PlayerController",
+								"connected": true
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P2",
+								"name": ""
+							},
+							{
+								"id": "P3",
+								"name": "On Success",
+								"connected": true
+							},
+							{
+								"id": "P4",
+								"name": "On Failure",
+								"connected": true
+							}
+						]
+					},
+					{
+						"id": "N31",
+						"type": "CustomEvent",
+						"name": "HideMainMenu",
+						"member_name": "None",
+						"input_pins": [],
+						"output_pins": [
+							{
+								"id": "P1",
+								"name": "Output Delegate",
+								"type": "Delegate"
+							},
+							{
+								"id": "P2",
+								"name": "",
+								"connected": true
+							}
+						]
+					},
+					{
+						"id": "N32",
+						"type": "MacroInstance",
+						"name": "Can Execute Cosmetic Events",
+						"member_parent": "StandardMacros",
+						"member_name": "Can Execute Cosmetic Events",
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "",
+								"connected": true
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P2",
+								"name": "True",
+								"connected": true
+							},
+							{
+								"id": "P3",
+								"name": "False"
+							}
+						]
+					},
+					{
+						"id": "N34",
+						"type": "VariableGet",
+						"name": "MenuRef",
+						"member_parent": "object/W_StartLogo",
+						"member_name": "MenuRef",
+						"pure": true,
+						"input_pins": [],
+						"output_pins": [
+							{
+								"id": "P1",
+								"name": "Menu Ref",
+								"type": "Object",
+								"sub_type": "W_StartLogo",
+								"connected": true
+							}
+						]
+					},
+					{
+						"id": "N33",
+						"type": "MacroInstance",
+						"name": "Is Valid",
+						"member_parent": "StandardMacros",
+						"member_name": "IsValid",
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "Exec",
+								"connected": true
+							},
+							{
+								"id": "P2",
+								"name": "Input Object",
+								"type": "Object",
+								"sub_type": "Object",
+								"connected": true
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P3",
+								"name": "Is Valid",
+								"connected": true
+							},
+							{
+								"id": "P4",
+								"name": "Is Not Valid"
+							}
+						]
+					},
+					{
+						"id": "N35",
+						"type": "CallFunction",
+						"name": "Remove from Parent",
+						"member_parent": "Widget",
+						"member_name": "RemoveFromParent",
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P3",
+								"name": "Target",
+								"type": "Object",
+								"sub_type": "Widget",
+								"connected": true
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P2",
+								"name": ""
+							}
+						]
+					},
+					{
+						"id": "N36",
+						"type": "CustomEvent",
+						"name": "ShowMainMenu",
+						"member_name": "None",
+						"input_pins": [],
+						"output_pins": [
+							{
+								"id": "P1",
+								"name": "Output Delegate",
+								"type": "Delegate"
+							},
+							{
+								"id": "P2",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P3",
+								"name": "With Anim",
+								"type": "Boolean",
+								"connected": true
+							}
+						]
+					},
+					{
+						"id": "N37",
+						"type": "MacroInstance",
+						"name": "Can Execute Cosmetic Events",
+						"member_parent": "StandardMacros",
+						"member_name": "Can Execute Cosmetic Events",
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "",
+								"connected": true
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P2",
+								"name": "True",
+								"connected": true
+							},
+							{
+								"id": "P3",
+								"name": "False"
+							}
+						]
+					},
+					{
+						"id": "N39",
+						"type": "ConstructObjectFromClass",
+						"name": "Create Widget",
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P3",
+								"name": "Class",
+								"type": "Class",
+								"sub_type": "UserWidget",
+								"default_value": "/Game/MagicCard/UI/Hall/Menu/W_StartLogo.W_StartLogo_C"
+							},
+							{
+								"id": "P5",
+								"name": "Owning Player",
+								"type": "Object",
+								"sub_type": "PlayerController"
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P2",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P4",
+								"name": "Return Value",
+								"type": "Object",
+								"sub_type": "W_StartLogo",
+								"connected": true
+							}
+						]
+					},
+					{
+						"id": "N41",
+						"type": "CallFunction",
+						"name": "Add to Viewport",
+						"member_parent": "UserWidget",
+						"member_name": "AddToViewport",
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P3",
+								"name": "Target",
+								"type": "Object",
+								"sub_type": "UserWidget",
+								"connected": true
+							},
+							{
+								"id": "P4",
+								"name": "ZOrder",
+								"type": "Integer",
+								"default_value": "5"
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P2",
+								"name": ""
+							}
+						]
+					},
+					{
+						"id": "N40",
+						"type": "VariableSet",
+						"name": "MenuRef",
+						"member_parent": "object/W_StartLogo",
+						"member_name": "MenuRef",
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P3",
+								"name": "Menu Ref",
+								"type": "Object",
+								"sub_type": "W_StartLogo",
+								"connected": true
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P2",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P4",
+								"name": "",
+								"type": "Object",
+								"sub_type": "W_StartLogo",
+								"connected": true
+							}
+						]
+					},
+					{
+						"id": "N38",
+						"type": "CallFunction",
+						"name": "Hide Main Menu",
+						"member_parent": "BP_MCGameInstance",
+						"member_name": "HideMainMenu",
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P3",
+								"name": "Target",
+								"type": "Object",
+								"sub_type": "self"
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P2",
+								"name": "",
+								"connected": true
+							}
+						]
+					},
+					{
+						"id": "N42",
+						"type": "CallFunction",
+						"name": "Play Menu Anim",
+						"member_parent": "W_StartLogo",
+						"member_name": "PlayMenuAnim",
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P3",
+								"name": "Target",
+								"type": "Object",
+								"sub_type": "W_StartLogo",
+								"connected": true
+							},
+							{
+								"id": "P4",
+								"name": "Play Anim",
+								"type": "Boolean",
+								"default_value": "false",
+								"connected": true
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P2",
+								"name": "",
+								"connected": true
+							}
+						]
+					},
+					{
+						"id": "N11",
+						"type": "CallFunction",
+						"name": "Show Main Menu",
+						"member_parent": "BP_MCGameInstance",
+						"member_name": "ShowMainMenu",
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P3",
+								"name": "Target",
+								"type": "Object",
+								"sub_type": "self"
+							},
+							{
+								"id": "P4",
+								"name": "With Anim",
+								"type": "Boolean",
+								"default_value": "true"
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P2",
+								"name": "",
+								"connected": true
+							}
+						]
+					},
+					{
+						"id": "N16",
+						"type": "VariableSet",
+						"name": "IsJoiningSession",
+						"member_parent": "bool",
+						"member_name": "IsJoiningSession",
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P3",
+								"name": "Is Joining Session",
+								"type": "Boolean",
+								"default_value": "true"
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P2",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P4",
+								"name": "",
+								"type": "Boolean",
+								"default_value": "false"
+							}
+						]
+					},
+					{
+						"id": "N22",
+						"type": "Branch",
+						"name": "Branch",
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P2",
+								"name": "Condition",
+								"type": "Boolean",
+								"default_value": "true",
+								"connected": true
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P3",
+								"name": "True",
+								"connected": true
+							},
+							{
+								"id": "P4",
+								"name": "False",
+								"connected": true
+							}
+						]
+					},
+					{
+						"id": "N44",
+						"type": "VariableGet",
+						"name": "IsJoiningSession",
+						"member_parent": "bool",
+						"member_name": "IsJoiningSession",
+						"pure": true,
+						"input_pins": [],
+						"output_pins": [
+							{
+								"id": "P1",
+								"name": "Is Joining Session",
+								"type": "Boolean",
+								"default_value": "false",
+								"connected": true
+							}
+						]
+					},
+					{
+						"id": "N20",
+						"type": "VariableSet",
+						"name": "IsJoiningSession",
+						"member_parent": "bool",
+						"member_name": "IsJoiningSession",
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P3",
+								"name": "Is Joining Session",
+								"type": "Boolean",
+								"default_value": "false"
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P2",
+								"name": ""
+							},
+							{
+								"id": "P4",
+								"name": "",
+								"type": "Boolean",
+								"default_value": "false"
+							}
+						]
+					},
+					{
+						"id": "N45",
+						"type": "VariableGet",
+						"name": "IsJoiningSession",
+						"member_parent": "bool",
+						"member_name": "IsJoiningSession",
+						"pure": true,
+						"input_pins": [],
+						"output_pins": [
+							{
+								"id": "P1",
+								"name": "Is Joining Session",
+								"type": "Boolean",
+								"default_value": "false",
+								"connected": true
+							}
+						]
+					},
+					{
+						"id": "N2",
+						"type": "Branch",
+						"name": "Branch",
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P2",
+								"name": "Condition",
+								"type": "Boolean",
+								"default_value": "true",
+								"connected": true
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P3",
+								"name": "True"
+							},
+							{
+								"id": "P4",
+								"name": "False",
+								"connected": true
+							}
+						]
+					},
+					{
+						"id": "N6",
+						"type": "VariableSet",
+						"name": "IsJoiningSession",
+						"member_parent": "bool",
+						"member_name": "IsJoiningSession",
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P3",
+								"name": "Is Joining Session",
+								"type": "Boolean",
+								"default_value": "true"
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P2",
+								"name": ""
+							},
+							{
+								"id": "P4",
+								"name": "",
+								"type": "Boolean",
+								"default_value": "false"
+							}
+						]
+					},
+					{
+						"id": "N4",
+						"type": "VariableSet",
+						"name": "IsJoiningSession",
+						"member_parent": "bool",
+						"member_name": "IsJoiningSession",
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P3",
+								"name": "Is Joining Session",
+								"type": "Boolean",
+								"default_value": "false"
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P2",
+								"name": ""
+							},
+							{
+								"id": "P4",
+								"name": "",
+								"type": "Boolean",
+								"default_value": "false"
+							}
+						]
+					},
+					{
+						"id": "N26",
+						"type": "VariableSet",
+						"name": "IsLocalGame",
+						"member_parent": "bool",
+						"member_name": "IsLocalGame",
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P3",
+								"name": "Is Local Game",
+								"type": "Boolean",
+								"default_value": "false"
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P2",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P4",
+								"name": "",
+								"type": "Boolean",
+								"default_value": "false"
+							}
+						]
+					},
+					{
+						"id": "N28",
+						"type": "VariableSet",
+						"name": "IsLocalGame",
+						"member_parent": "bool",
+						"member_name": "IsLocalGame",
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P3",
+								"name": "Is Local Game",
+								"type": "Boolean",
+								"default_value": "false"
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P2",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P4",
+								"name": "",
+								"type": "Boolean",
+								"default_value": "false"
+							}
+						]
+					},
+					{
+						"id": "N43",
+						"type": "CallFunction",
+						"name": "Print String",
+						"member_parent": "KismetSystemLibrary",
+						"member_name": "PrintString",
+						"input_pins": [
+							{
+								"id": "P1",
+								"name": "",
+								"connected": true
+							},
+							{
+								"id": "P3",
+								"name": "In String",
+								"type": "String",
+								"default_value": "Already Joining Session"
+							},
+							{
+								"id": "P4",
+								"name": "Print to Screen",
+								"type": "Boolean",
+								"default_value": "true"
+							},
+							{
+								"id": "P5",
+								"name": "Print to Log",
+								"type": "Boolean",
+								"default_value": "true"
+							},
+							{
+								"id": "P6",
+								"name": "Text Color",
+								"type": "Struct",
+								"sub_type": "LinearColor",
+								"default_value": "(R=0.000000,G=0.660000,B=1.000000,A=1.000000)"
+							},
+							{
+								"id": "P7",
+								"name": "Duration",
+								"type": "Real",
+								"sub_type": "float",
+								"default_value": "2.000000"
+							},
+							{
+								"id": "P8",
+								"name": "Key",
+								"type": "Name",
+								"default_value": "None",
+								"is_const": true
+							}
+						],
+						"output_pins": [
+							{
+								"id": "P2",
+								"name": ""
+							}
+						]
+					},
+					{
+						"id": "N46",
+						"type": "VariableGet",
+						"name": "Level Name",
+						"member_parent": "name",
+						"member_name": "Level Name",
+						"pure": true,
+						"input_pins": [],
+						"output_pins": [
+							{
+								"id": "P1",
+								"name": "Level Name",
+								"type": "Name",
+								"default_value": "None",
+								"connected": true
+							}
+						]
+					}
+				],
+				"flows":
+				{
+					"execution": [
+						"N1->N2",
+						"N3->N4",
+						"N5->N6",
+						"N7->N4",
+						"N9->N10",
+						"N10->N11",
+						"N13->N14",
+						"N15->N16",
+						"N15->N17",
+						"N15->N18",
+						"N17->N20",
+						"N18->N20",
+						"N21->N22",
+						"N14->N24",
+						"N25->N5",
+						"N25->N26",
+						"N25->N7",
+						"N27->N28",
+						"N30->N25",
+						"N31->N32",
+						"N32->N33",
+						"N33->N35",
+						"N36->N37",
+						"N37->N38",
+						"N39->N40",
+						"N40->N42",
+						"N38->N39",
+						"N42->N41",
+						"N11->N13",
+						"N16->N19",
+						"N22->N43",
+						"N22->N27",
+						"N2->N30",
+						"N26->N3",
+						"N28->N15"
+					],
+					"data":
+					{
+						"N12.P2": "N24.P3",
+						"N21.P3": "N15.P6",
+						"N23.P2": "N27.P5",
+						"N9.P3": "N14.P4",
+						"N8.P2": "N25.P6",
+						"N29.P2": "N30.P5",
+						"N34.P1": "N35.P3",
+						"N39.P4": "N40.P3",
+						"N40.P4": "N42.P3",
+						"N36.P3": "N42.P4",
+						"N44.P1": "N22.P2",
+						"N45.P1": "N2.P2",
+						"N46.P1": "N3.P3"
+					}
+				}
+			}
+		],
+		"structs": [],
+		"enums": []
+	}

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 ### 💬 **Blueprint Communication Solved**
 - 🆕 Support for Claude 4, Gemini 2.5 Flash, & OpenAI's latest models
 - 🆕 Support for LM Studio -> [Quick Start Guide](https://github.com/protospatial/NodeToCode/wiki/LM-Studio-Quick-Start)
+- 🆕 **Complete Blueprint Translation:** Translate entire Blueprints with all graphs, variables, and components at once
+- 🆕 **Variable & Component Support:** Full support for Blueprint variables, local variables, and component overrides
 - **Pseudocode Translation:** Convert Blueprints into universally understandable pseudocode
 - **Automatic Translation Saving:** Each translation is saved locally for easy archiving & sharing via chat or docs
 - Share complete Blueprint logic as text in forums, chat, emails, or documentation
@@ -45,6 +47,8 @@
 ## 🔧 Under the Hood
 
 - **Blueprint Analysis:** Captures your entire Blueprint graph structure, including execution flows, data connections, variable references, and comments
+- **Complete Blueprint Translation:** Translate entire Blueprints with all graphs, variables, and components in a single operation
+- **Variable & Component Support:** Full support for Blueprint-level variables, local variables, and component property overrides
 - **Multiple LLM Options:** Use cloud providers (OpenAI, Anthropic Claude, Google Gemini, DeepSeek) or run 100% locally via Ollama for complete privacy
 - **Efficient Serialization:** Converts blueprints into a bespoke JSON schema that reduces token usage by 60-90% compared to UE's verbose Blueprint text format
 - **Style Guidance:** Supply your own C++ files as reference to maintain your project's coding standards and patterns
@@ -56,6 +60,29 @@
 - **C++ Programmers:** Understand designer intent without deciphering complex visual graphs
 - **Project Leads:** Improve team communication and maintain better system documentation
 - **Educators & Students:** Bridge the visual-to-code learning gap with real examples
+
+## 🆕 Recent Updates
+
+### Complete Blueprint Translation
+- **Translate Entire Blueprint:** New toolbar command to translate all graphs in a Blueprint at once
+- **Batch Processing:** Each graph generates independent JSON and LLM requests, all sharing the same root directory
+- **Error Feedback:** Comprehensive success/failure reporting for batch translations
+
+### Enhanced Variable & Component Support
+- **Blueprint Variables:** Full support for Blueprint-level variables with complete type mapping (including Array, Set, Map)
+- **Local Variables:** Function-level local variable collection and serialization
+- **Component Overrides:** Automatic detection and serialization of component property overrides
+- **Component Hierarchy:** Support for component parent-child relationships
+- **Map Key Types:** Improved Map key type extraction from Blueprint pin types
+
+### ClassItSelf Graph Type
+- **Class Structure Marking:** New graph type for representing class skeleton structure
+- **C++ Class Generation:** Enables LLM to generate proper C++ class declarations, constructors, and member variables
+- **Conditional Creation:** Automatically created when variables or components are present
+
+### Code Generation Improvements
+- **Enhanced Prompts:** Significantly expanded CodeGen_CPP.md with detailed guidance for components, variables, class structures, event handling, and network replication
+- **Better Type Mapping:** Improved handling of complex Unreal Engine types
 
 ## 🏃Get Started
 

--- a/Source/NodeToCode.Build.cs
+++ b/Source/NodeToCode.Build.cs
@@ -23,7 +23,7 @@ public class NodeToCode : ModuleRules
 			{
 				"Core",
 				"CoreUObject",
-				"Engine", 
+				"Engine",
 				"InputCore",
 				"Json",
 				"UnrealEd",
@@ -36,7 +36,8 @@ public class NodeToCode : ModuleRules
 				"UMG",
 				"ToolMenus",
 				"ApplicationCore",
-				"Projects"
+				"Projects",
+				"AssetRegistry"
 			}
 		);
         

--- a/Source/Private/Commandlets/N2CBatchBlueprintCommandlet.cpp
+++ b/Source/Private/Commandlets/N2CBatchBlueprintCommandlet.cpp
@@ -1,0 +1,527 @@
+// Copyright (c) 2025 Nick McClure (Protospatial). All Rights Reserved.
+
+#include "Commandlets/N2CBatchBlueprintCommandlet.h"
+
+#if WITH_EDITOR
+
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "Engine/Blueprint.h"
+#include "EdGraph/EdGraph.h"
+#include "K2Node.h"
+#include "Misc/FileHelper.h"
+#include "HAL/FileManager.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+
+// NodeToCode includes
+#include "Core/N2CNodeCollector.h"
+#include "Core/N2CNodeTranslator.h"
+#include "Core/N2CSerializer.h"
+#include "Core/N2CSettings.h"
+
+DEFINE_LOG_CATEGORY_STATIC(LogN2CBatchBlueprint, Log, All);
+
+UN2CBatchBlueprintCommandlet::UN2CBatchBlueprintCommandlet()
+{
+    IsClient = false;
+    IsEditor = true;
+    IsServer = false;
+    LogToConsole = true;
+}
+
+int32 UN2CBatchBlueprintCommandlet::Main(const FString& Params)
+{
+    UE_LOG(LogN2CBatchBlueprint, Display, TEXT("=== NodeToCode Batch Blueprint Conversion ==="));
+    UE_LOG(LogN2CBatchBlueprint, Display, TEXT("Parameters: %s"), *Params);
+
+    // Parse command line
+    ParseParams(Params);
+
+    UE_LOG(LogN2CBatchBlueprint, Display, TEXT("Search Path: %s"), *SearchPath);
+    UE_LOG(LogN2CBatchBlueprint, Display, TEXT("Dry Run: %s"), bDryRun ? TEXT("Yes") : TEXT("No"));
+    UE_LOG(LogN2CBatchBlueprint, Display, TEXT("Exclude Widgets: %s"), bExcludeWidgets ? TEXT("Yes") : TEXT("No"));
+    UE_LOG(LogN2CBatchBlueprint, Display, TEXT("Exclude AnimBP: %s"), bExcludeAnimBP ? TEXT("Yes") : TEXT("No"));
+
+    if (IncludeList.Num() > 0)
+    {
+        UE_LOG(LogN2CBatchBlueprint, Display, TEXT("Include Filter: %s"), *FString::Join(IncludeList, TEXT(", ")));
+    }
+    if (ExcludeList.Num() > 0)
+    {
+        UE_LOG(LogN2CBatchBlueprint, Display, TEXT("Exclude Filter: %s"), *FString::Join(ExcludeList, TEXT(", ")));
+    }
+
+    // Discover Blueprints
+    TArray<FAssetData> BlueprintAssets = DiscoverBlueprints();
+
+    if (BlueprintAssets.Num() == 0)
+    {
+        UE_LOG(LogN2CBatchBlueprint, Warning, TEXT("No Blueprints found matching criteria"));
+        return 0;
+    }
+
+    UE_LOG(LogN2CBatchBlueprint, Display, TEXT("Found %d Blueprint(s) to process:"), BlueprintAssets.Num());
+    for (const FAssetData& Asset : BlueprintAssets)
+    {
+        UE_LOG(LogN2CBatchBlueprint, Display, TEXT("  - %s"), *Asset.AssetName.ToString());
+    }
+
+    // Dry run mode - just list and exit
+    if (bDryRun)
+    {
+        UE_LOG(LogN2CBatchBlueprint, Display, TEXT("Dry run complete. Use without -DryRun to convert."));
+        return 0;
+    }
+
+    // Load API key from environment or secrets file
+    ApiKey = FPlatformMisc::GetEnvironmentVariable(TEXT("ANTHROPIC_API_KEY"));
+
+    if (ApiKey.IsEmpty())
+    {
+        // Try loading from NodeToCode secrets file
+        FString SecretsFilePath = FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("NodeToCode"), TEXT("User"), TEXT("secrets.json"));
+        FString SecretsJson;
+        if (FFileHelper::LoadFileToString(SecretsJson, *SecretsFilePath))
+        {
+            TSharedPtr<FJsonObject> JsonObject;
+            TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(SecretsJson);
+            if (FJsonSerializer::Deserialize(Reader, JsonObject) && JsonObject.IsValid())
+            {
+                ApiKey = JsonObject->GetStringField(TEXT("Anthropic_API_Key"));
+            }
+        }
+    }
+
+    if (ApiKey.IsEmpty())
+    {
+        UE_LOG(LogN2CBatchBlueprint, Error, TEXT("No API key found. Set ANTHROPIC_API_KEY environment variable or configure in NodeToCode plugin settings."));
+        return 1;
+    }
+
+    UE_LOG(LogN2CBatchBlueprint, Display, TEXT("API key loaded successfully"));
+
+    // Process each Blueprint (synchronous using curl subprocess)
+    for (const FAssetData& AssetData : BlueprintAssets)
+    {
+        UBlueprint* Blueprint = Cast<UBlueprint>(AssetData.GetAsset());
+        if (!Blueprint)
+        {
+            UE_LOG(LogN2CBatchBlueprint, Warning, TEXT("Failed to load Blueprint: %s"), *AssetData.AssetName.ToString());
+            FailureCount.Increment();
+            continue;
+        }
+
+        UE_LOG(LogN2CBatchBlueprint, Display, TEXT("Processing: %s"), *Blueprint->GetName());
+
+        if (ProcessBlueprint(Blueprint))
+        {
+            UE_LOG(LogN2CBatchBlueprint, Display, TEXT("  Translation complete"));
+        }
+        else
+        {
+            UE_LOG(LogN2CBatchBlueprint, Warning, TEXT("  Failed to process"));
+            FailureCount.Increment();
+        }
+    }
+
+    // Summary
+    FString OutputDir = FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("NodeToCode"), TEXT("Translations"));
+    UE_LOG(LogN2CBatchBlueprint, Display, TEXT("=== Conversion Complete ==="));
+    UE_LOG(LogN2CBatchBlueprint, Display, TEXT("Successful: %d"), SuccessCount.GetValue());
+    UE_LOG(LogN2CBatchBlueprint, Display, TEXT("Failed: %d"), FailureCount.GetValue());
+    UE_LOG(LogN2CBatchBlueprint, Display, TEXT("Output: %s"), *OutputDir);
+
+    return FailureCount.GetValue() > 0 ? 1 : 0;
+}
+
+void UN2CBatchBlueprintCommandlet::ParseParams(const FString& InParams)
+{
+    TArray<FString> Tokens;
+    TArray<FString> Switches;
+    TMap<FString, FString> ParamMap;
+
+    UCommandlet::ParseCommandLine(*InParams, Tokens, Switches, ParamMap);
+
+    // Check for switches
+    bDryRun = Switches.Contains(TEXT("DryRun")) || Switches.Contains(TEXT("dryrun"));
+    bExcludeWidgets = Switches.Contains(TEXT("ExcludeWidgets")) || Switches.Contains(TEXT("excludewidgets"));
+    bExcludeAnimBP = Switches.Contains(TEXT("ExcludeAnimBP")) || Switches.Contains(TEXT("excludeanimbp"));
+
+    // Check for parameters
+    if (const FString* PathValue = ParamMap.Find(TEXT("Path")))
+    {
+        SearchPath = *PathValue;
+    }
+
+    if (const FString* IncludeValue = ParamMap.Find(TEXT("Include")))
+    {
+        IncludeValue->ParseIntoArray(IncludeList, TEXT(","), true);
+        for (FString& Name : IncludeList)
+        {
+            Name.TrimStartAndEndInline();
+        }
+    }
+
+    if (const FString* ExcludeValue = ParamMap.Find(TEXT("Exclude")))
+    {
+        ExcludeValue->ParseIntoArray(ExcludeList, TEXT(","), true);
+        for (FString& Name : ExcludeList)
+        {
+            Name.TrimStartAndEndInline();
+        }
+    }
+}
+
+TArray<FAssetData> UN2CBatchBlueprintCommandlet::DiscoverBlueprints()
+{
+    TArray<FAssetData> Result;
+
+    FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+    IAssetRegistry& AssetRegistry = AssetRegistryModule.Get();
+
+    // Ensure asset registry is ready
+    AssetRegistry.SearchAllAssets(true);
+
+    // Query for Blueprint assets
+    FARFilter Filter;
+    Filter.ClassPaths.Add(UBlueprint::StaticClass()->GetClassPathName());
+    Filter.bRecursiveClasses = true;
+    Filter.bRecursivePaths = true;
+    Filter.PackagePaths.Add(FName(*SearchPath));
+
+    TArray<FAssetData> AllBlueprints;
+    AssetRegistry.GetAssets(Filter, AllBlueprints);
+
+    // Apply filters
+    for (const FAssetData& AssetData : AllBlueprints)
+    {
+        if (!ShouldExcludeBlueprint(AssetData))
+        {
+            Result.Add(AssetData);
+        }
+    }
+
+    return Result;
+}
+
+bool UN2CBatchBlueprintCommandlet::ShouldExcludeBlueprint(const FAssetData& AssetData) const
+{
+    FString AssetName = AssetData.AssetName.ToString();
+    FString PackagePath = AssetData.PackagePath.ToString();
+
+    // Check explicit include list first
+    if (IncludeList.Num() > 0)
+    {
+        bool bInIncludeList = false;
+        for (const FString& IncludeName : IncludeList)
+        {
+            if (AssetName.Equals(IncludeName, ESearchCase::IgnoreCase))
+            {
+                bInIncludeList = true;
+                break;
+            }
+        }
+        if (!bInIncludeList)
+        {
+            return true; // Not in include list, exclude it
+        }
+    }
+
+    // Check explicit exclude list
+    for (const FString& ExcludeName : ExcludeList)
+    {
+        if (AssetName.Equals(ExcludeName, ESearchCase::IgnoreCase))
+        {
+            return true;
+        }
+    }
+
+    // Exclude Widget Blueprints if requested
+    if (bExcludeWidgets)
+    {
+        if (AssetName.StartsWith(TEXT("WBP_"), ESearchCase::IgnoreCase) ||
+            AssetName.StartsWith(TEXT("W_"), ESearchCase::IgnoreCase) ||
+            AssetName.StartsWith(TEXT("Widget_"), ESearchCase::IgnoreCase))
+        {
+            return true;
+        }
+    }
+
+    // Exclude Animation Blueprints if requested
+    if (bExcludeAnimBP)
+    {
+        if (AssetName.StartsWith(TEXT("ABP_"), ESearchCase::IgnoreCase) ||
+            AssetName.StartsWith(TEXT("AnimBP_"), ESearchCase::IgnoreCase))
+        {
+            return true;
+        }
+    }
+
+    // Always exclude engine content
+    if (PackagePath.StartsWith(TEXT("/Engine/")))
+    {
+        return true;
+    }
+
+    // Check parent class for Widget/Animation types if exclusion flags are set
+    if (bExcludeWidgets || bExcludeAnimBP)
+    {
+        FAssetTagValueRef ParentClassTag = AssetData.TagsAndValues.FindTag(FName(TEXT("ParentClass")));
+        if (ParentClassTag.IsSet())
+        {
+            FString ParentClassName = ParentClassTag.AsString();
+            if (bExcludeWidgets && ParentClassName.Contains(TEXT("UserWidget")))
+            {
+                return true;
+            }
+            if (bExcludeAnimBP && ParentClassName.Contains(TEXT("AnimInstance")))
+            {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+bool UN2CBatchBlueprintCommandlet::ProcessBlueprint(UBlueprint* Blueprint)
+{
+    if (!Blueprint)
+    {
+        return false;
+    }
+
+    // Get all graphs from the Blueprint
+    TArray<UEdGraph*> AllGraphs;
+    Blueprint->GetAllGraphs(AllGraphs);
+
+    if (AllGraphs.Num() == 0)
+    {
+        UE_LOG(LogN2CBatchBlueprint, Warning, TEXT("  No graphs found in Blueprint"));
+        return false;
+    }
+
+    UE_LOG(LogN2CBatchBlueprint, Display, TEXT("  Found %d graph(s)"), AllGraphs.Num());
+
+    // Process each graph
+    FN2CNodeCollector& Collector = FN2CNodeCollector::Get();
+    FN2CNodeTranslator& Translator = FN2CNodeTranslator::Get();
+    FString BlueprintName = Blueprint->GetName();
+    bool bAnySuccess = false;
+
+    // System prompt for code generation
+    FString SystemPrompt = TEXT("You are an expert Unreal Engine C++ programmer. Convert the following Blueprint graph JSON to equivalent C++ code. Output clean, production-ready code with appropriate UPROPERTY and UFUNCTION macros. Include both header declarations and implementation.");
+
+    for (UEdGraph* Graph : AllGraphs)
+    {
+        if (!Graph)
+        {
+            continue;
+        }
+
+        FString GraphName = Graph->GetName();
+        UE_LOG(LogN2CBatchBlueprint, Display, TEXT("  Processing graph: %s"), *GraphName);
+
+        // Collect nodes from the graph
+        TArray<UK2Node*> CollectedNodes;
+        if (!Collector.CollectNodesFromGraph(Graph, CollectedNodes))
+        {
+            UE_LOG(LogN2CBatchBlueprint, Warning, TEXT("    Failed to collect nodes"));
+            continue;
+        }
+
+        if (CollectedNodes.Num() == 0)
+        {
+            UE_LOG(LogN2CBatchBlueprint, Display, TEXT("    No K2 nodes in graph, skipping"));
+            continue;
+        }
+
+        UE_LOG(LogN2CBatchBlueprint, Display, TEXT("    Collected %d node(s)"), CollectedNodes.Num());
+
+        // Translate nodes to N2C format
+        if (!Translator.GenerateN2CStruct(CollectedNodes))
+        {
+            UE_LOG(LogN2CBatchBlueprint, Warning, TEXT("    Failed to translate nodes"));
+            continue;
+        }
+
+        const FN2CBlueprint& N2CBlueprint = Translator.GetN2CBlueprint();
+        if (!N2CBlueprint.IsValid())
+        {
+            UE_LOG(LogN2CBatchBlueprint, Warning, TEXT("    Invalid N2C Blueprint structure"));
+            continue;
+        }
+
+        // Serialize to JSON
+        FN2CSerializer::SetPrettyPrint(false);
+        FString JsonOutput = FN2CSerializer::ToJson(N2CBlueprint);
+
+        if (JsonOutput.IsEmpty())
+        {
+            UE_LOG(LogN2CBatchBlueprint, Warning, TEXT("    JSON serialization failed"));
+            continue;
+        }
+
+        // Call LLM via curl subprocess (synchronous)
+        FString Response = CallCurlForLLMRequest(JsonOutput, SystemPrompt);
+
+        if (Response.IsEmpty())
+        {
+            UE_LOG(LogN2CBatchBlueprint, Error, TEXT("    Empty response for %s::%s"), *BlueprintName, *GraphName);
+            FailureCount.Increment();
+        }
+        else
+        {
+            UE_LOG(LogN2CBatchBlueprint, Display, TEXT("    Received response (%d chars)"), Response.Len());
+            SaveTranslationResult(BlueprintName, GraphName, Response);
+            SuccessCount.Increment();
+            bAnySuccess = true;
+        }
+    }
+
+    return bAnySuccess;
+}
+
+void UN2CBatchBlueprintCommandlet::WaitForPendingRequests()
+{
+    // Not needed - using synchronous curl subprocess
+}
+
+FString UN2CBatchBlueprintCommandlet::CallCurlForLLMRequest(const FString& JsonPayload, const FString& SystemPrompt)
+{
+    // Create temp file for the request payload
+    FString TempPayloadFile = FPaths::CreateTempFilename(*FPaths::ProjectSavedDir(), TEXT("n2c_"), TEXT(".json"));
+
+    // Build the Anthropic API request body
+    // Escape the JSON payload for embedding in the request
+    FString EscapedPayload = JsonPayload.Replace(TEXT("\\"), TEXT("\\\\")).Replace(TEXT("\""), TEXT("\\\"")).Replace(TEXT("\n"), TEXT("\\n")).Replace(TEXT("\r"), TEXT(""));
+    FString EscapedSystemPrompt = SystemPrompt.Replace(TEXT("\\"), TEXT("\\\\")).Replace(TEXT("\""), TEXT("\\\"")).Replace(TEXT("\n"), TEXT("\\n")).Replace(TEXT("\r"), TEXT(""));
+
+    FString RequestBody = FString::Printf(
+        TEXT("{\"model\":\"claude-sonnet-4-20250514\",\"max_tokens\":8192,\"system\":\"%s\",\"messages\":[{\"role\":\"user\",\"content\":\"%s\"}]}"),
+        *EscapedSystemPrompt,
+        *EscapedPayload
+    );
+
+    // Write request to temp file
+    if (!FFileHelper::SaveStringToFile(RequestBody, *TempPayloadFile))
+    {
+        UE_LOG(LogN2CBatchBlueprint, Error, TEXT("Failed to write temp payload file"));
+        return TEXT("");
+    }
+
+    // Build curl command - output directly to file
+    FString TempOutputFile = FPaths::CreateTempFilename(*FPaths::ProjectSavedDir(), TEXT("n2c_out_"), TEXT(".json"));
+
+    // Use curl with output to file
+    FString CurlCmd = FString::Printf(
+        TEXT("curl -s -o \"%s\" -X POST \"https://api.anthropic.com/v1/messages\" -H \"x-api-key: %s\" -H \"anthropic-version: 2023-06-01\" -H \"content-type: application/json\" -d @\"%s\""),
+        *TempOutputFile,
+        *ApiKey,
+        *TempPayloadFile
+    );
+
+    UE_LOG(LogN2CBatchBlueprint, Display, TEXT("    Calling Anthropic API..."));
+
+    FString StdOut, StdErr;
+    int32 ReturnCode = -1;
+
+    // Platform-specific command execution
+#if PLATFORM_WINDOWS
+    FString CmdExe = TEXT("cmd.exe");
+    FString CmdArgs = FString::Printf(TEXT("/c %s"), *CurlCmd);
+#else
+    FString CmdExe = TEXT("/bin/sh");
+    FString CmdArgs = FString::Printf(TEXT("-c \"%s\""), *CurlCmd);
+#endif
+
+    // Execute curl
+    bool bSuccess = FPlatformProcess::ExecProcess(
+        *CmdExe,
+        *CmdArgs,
+        &ReturnCode,
+        &StdOut,
+        &StdErr
+    );
+
+    // Clean up payload file
+    IFileManager::Get().Delete(*TempPayloadFile);
+
+    if (!bSuccess)
+    {
+        UE_LOG(LogN2CBatchBlueprint, Error, TEXT("curl failed to execute: %s"), *StdErr);
+        IFileManager::Get().Delete(*TempOutputFile);
+        return TEXT("");
+    }
+
+    // Read the output file
+    FString ResponseContent;
+    if (!FFileHelper::LoadFileToString(ResponseContent, *TempOutputFile))
+    {
+        UE_LOG(LogN2CBatchBlueprint, Error, TEXT("Failed to read curl output file: %s"), *TempOutputFile);
+        IFileManager::Get().Delete(*TempOutputFile);
+        return TEXT("");
+    }
+
+    // Clean up output file
+    IFileManager::Get().Delete(*TempOutputFile);
+
+    if (ResponseContent.IsEmpty())
+    {
+        UE_LOG(LogN2CBatchBlueprint, Error, TEXT("Empty response from API"));
+        return TEXT("");
+    }
+
+    // Parse the response to extract the content
+    TSharedPtr<FJsonObject> JsonResponse;
+    TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(ResponseContent);
+    if (!FJsonSerializer::Deserialize(Reader, JsonResponse) || !JsonResponse.IsValid())
+    {
+        UE_LOG(LogN2CBatchBlueprint, Error, TEXT("Failed to parse API response: %s"), *ResponseContent.Left(500));
+        return TEXT("");
+    }
+
+    // Check for error
+    if (JsonResponse->HasField(TEXT("error")))
+    {
+        TSharedPtr<FJsonObject> ErrorObj = JsonResponse->GetObjectField(TEXT("error"));
+        FString ErrorMessage = ErrorObj->GetStringField(TEXT("message"));
+        UE_LOG(LogN2CBatchBlueprint, Error, TEXT("API error: %s"), *ErrorMessage);
+        return TEXT("");
+    }
+
+    // Extract content from response
+    const TArray<TSharedPtr<FJsonValue>>* ContentArray;
+    if (JsonResponse->TryGetArrayField(TEXT("content"), ContentArray) && ContentArray->Num() > 0)
+    {
+        TSharedPtr<FJsonObject> ContentObj = (*ContentArray)[0]->AsObject();
+        if (ContentObj.IsValid())
+        {
+            FString ContentText = ContentObj->GetStringField(TEXT("text"));
+            return ContentText;
+        }
+    }
+
+    UE_LOG(LogN2CBatchBlueprint, Error, TEXT("Unexpected response format"));
+    return TEXT("");
+}
+
+void UN2CBatchBlueprintCommandlet::SaveTranslationResult(const FString& BlueprintName, const FString& GraphName, const FString& Response)
+{
+    // Create output directory
+    FString OutputDir = FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("NodeToCode"), TEXT("Translations"), BlueprintName);
+    IFileManager::Get().MakeDirectory(*OutputDir, true);
+
+    // Save the response
+    FString OutputFile = FPaths::Combine(OutputDir, GraphName + TEXT(".txt"));
+    if (FFileHelper::SaveStringToFile(Response, *OutputFile))
+    {
+        UE_LOG(LogN2CBatchBlueprint, Display, TEXT("    Saved: %s"), *OutputFile);
+    }
+    else
+    {
+        UE_LOG(LogN2CBatchBlueprint, Warning, TEXT("    Failed to save: %s"), *OutputFile);
+    }
+}
+
+#endif // WITH_EDITOR

--- a/Source/Private/Core/N2CToolbarCommand.cpp
+++ b/Source/Private/Core/N2CToolbarCommand.cpp
@@ -11,12 +11,15 @@
 const FName FN2CToolbarCommand::CommandName_Open = TEXT("NodeToCode_OpenWindow");
 const FName FN2CToolbarCommand::CommandName_Collect = TEXT("NodeToCode_CollectNodes");
 const FName FN2CToolbarCommand::CommandName_CopyJson = TEXT("NodeToCode_CopyJson");
+const FName FN2CToolbarCommand::CommandName_TranslateEntire = TEXT("NodeToCode_TranslateEntireBlueprint");
 const FText FN2CToolbarCommand::CommandLabel_Open = NSLOCTEXT("NodeToCode", "OpenWindow", "Open Node to Code");
 const FText FN2CToolbarCommand::CommandLabel_Collect = NSLOCTEXT("NodeToCode", "CollectNodes", "Collect and Translate Nodes");
 const FText FN2CToolbarCommand::CommandLabel_CopyJson = NSLOCTEXT("NodeToCode", "CopyJson", "Copy Blueprint JSON");
+const FText FN2CToolbarCommand::CommandLabel_TranslateEntire = NSLOCTEXT("NodeToCode", "TranslateEntireBlueprint", "Translate Entire Blueprint");
 const FText FN2CToolbarCommand::CommandTooltip_Open = NSLOCTEXT("NodeToCode", "OpenWindowTooltip", "Open the Node to Code window");
 const FText FN2CToolbarCommand::CommandTooltip_Collect = NSLOCTEXT("NodeToCode", "CollectNodesTooltip", "Collect nodes from current Blueprint graph and translate to code");
 const FText FN2CToolbarCommand::CommandTooltip_CopyJson = NSLOCTEXT("NodeToCode", "CopyJsonTooltip", "Copy the serialized Blueprint JSON to clipboard");
+const FText FN2CToolbarCommand::CommandTooltip_TranslateEntire = NSLOCTEXT("NodeToCode", "TranslateEntireTooltip", "Translate all graphs in the owning Blueprint (functions, macros, event graphs).\nRespects 'Include Variables' setting.");
 
 FN2CToolbarCommand::FN2CToolbarCommand()
     : TCommands<FN2CToolbarCommand>(
@@ -55,6 +58,14 @@ void FN2CToolbarCommand::RegisterCommands()
     EUserInterfaceActionType::Button,
     FInputChord()
 );
+    
+    UI_COMMAND(
+        TranslateEntireBlueprintCommand,
+        "Translate Entire Blueprint",
+        "Translate all graphs in the owning Blueprint to code. Results will be shown in the Node to Code window.",
+        EUserInterfaceActionType::Button,
+        FInputChord()
+    );
     
     FN2CLogger::Get().Log(TEXT("N2C toolbar commands registered"), EN2CLogSeverity::Debug);
 }

--- a/Source/Private/LLM/N2CLLMModule.cpp
+++ b/Source/Private/LLM/N2CLLMModule.cpp
@@ -115,11 +115,11 @@ void UN2CLLMModule::ProcessN2CJson(
 
     // Send request through service
     ActiveService->SendRequest(JsonInput, SystemPrompt, FOnLLMResponseReceived::CreateLambda(
-        [this](const FString& Response)
+        [this, OnComplete](const FString& Response)
         {
             // Create translation response struct
             FN2CTranslationResponse TranslationResponse;
-            
+
             // Get active service's response parser
             TScriptInterface<IN2CLLMService> ActiveServiceParser = GetActiveService();
             if (ActiveServiceParser.GetInterface())
@@ -130,22 +130,24 @@ void UN2CLLMModule::ProcessN2CJson(
                     if (Parser->ParseLLMResponse(Response, TranslationResponse))
                     {
                         CurrentStatus = EN2CSystemStatus::Idle;
-                            
+
                         // Save translation to disk
                         const FN2CBlueprint& Blueprint = FN2CNodeTranslator::Get().GetN2CBlueprint();
                         if (SaveTranslationToDisk(TranslationResponse, Blueprint))
                         {
                             FN2CLogger::Get().Log(TEXT("Successfully saved translation to disk"), EN2CLogSeverity::Info);
                         }
-                            
+
                         OnTranslationResponseReceived.Broadcast(TranslationResponse, true);
                         FN2CLogger::Get().Log(TEXT("Successfully parsed LLM response"), EN2CLogSeverity::Info);
+                        OnComplete.ExecuteIfBound(Response);
                     }
                     else
                     {
                         CurrentStatus = EN2CSystemStatus::Error;
                         FN2CLogger::Get().LogError(TEXT("Failed to parse LLM response"));
                         OnTranslationResponseReceived.Broadcast(TranslationResponse, false);
+                        OnComplete.ExecuteIfBound(Response);
                     }
                 }
                 else
@@ -153,6 +155,7 @@ void UN2CLLMModule::ProcessN2CJson(
                     CurrentStatus = EN2CSystemStatus::Error;
                     FN2CLogger::Get().LogError(TEXT("No response parser available"));
                     OnTranslationResponseReceived.Broadcast(TranslationResponse, false);
+                    OnComplete.ExecuteIfBound(TEXT("{\"error\": \"No response parser\"}"));
                 }
             }
             else
@@ -160,6 +163,7 @@ void UN2CLLMModule::ProcessN2CJson(
                 CurrentStatus = EN2CSystemStatus::Error;
                 FN2CLogger::Get().LogError(TEXT("No active LLM service"));
                 OnTranslationResponseReceived.Broadcast(TranslationResponse, false);
+                OnComplete.ExecuteIfBound(TEXT("{\"error\": \"No active service\"}"));
             }
         }));
 }

--- a/Source/Public/Commandlets/N2CBatchBlueprintCommandlet.h
+++ b/Source/Public/Commandlets/N2CBatchBlueprintCommandlet.h
@@ -1,0 +1,98 @@
+// Copyright (c) 2025 Nick McClure (Protospatial). All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+#if WITH_EDITOR
+
+#include "Commandlets/Commandlet.h"
+#include "N2CBatchBlueprintCommandlet.generated.h"
+
+struct FAssetData;
+class UBlueprint;
+
+/**
+ * Commandlet for batch converting Blueprints to C++ using NodeToCode plugin.
+ *
+ * Usage:
+ *   UnrealEditor-Cmd.exe Project.uproject -run=N2CBatchBlueprint [options]
+ *
+ * Options:
+ *   -DryRun           List Blueprints without converting
+ *   -Path=/Game/...   Root path to search (default: /Game/)
+ *   -Include=BP1,BP2  Only convert these Blueprints (comma-separated names)
+ *   -Exclude=BP1,BP2  Skip these Blueprints (comma-separated names)
+ *   -ExcludeWidgets   Skip Widget Blueprints (WBP_* or UserWidget parents)
+ *   -ExcludeAnimBP    Skip Animation Blueprints (ABP_* or AnimInstance parents)
+ *
+ * Environment:
+ *   ANTHROPIC_API_KEY - Required API key for Anthropic LLM service
+ *                       (or configure in NodeToCode plugin settings)
+ *
+ * Output:
+ *   Generated code is saved to: Saved/NodeToCode/Translations/<BlueprintName>/
+ */
+UCLASS()
+class NODETOCODE_API UN2CBatchBlueprintCommandlet : public UCommandlet
+{
+    GENERATED_BODY()
+
+public:
+    UN2CBatchBlueprintCommandlet();
+    virtual int32 Main(const FString& Params) override;
+
+private:
+    /** Parse command line parameters */
+    void ParseParams(const FString& InParams);
+
+    /** Discover Blueprint assets in the search path */
+    TArray<FAssetData> DiscoverBlueprints();
+
+    /** Check if a Blueprint should be excluded based on filters */
+    bool ShouldExcludeBlueprint(const FAssetData& AssetData) const;
+
+    /** Process a single Blueprint through NodeToCode */
+    bool ProcessBlueprint(UBlueprint* Blueprint);
+
+    /** Wait for all pending LLM requests to complete */
+    void WaitForPendingRequests();
+
+    /** Dry run mode - list files without converting */
+    bool bDryRun = false;
+
+    /** Root path to search for Blueprints */
+    FString SearchPath = TEXT("/Game/");
+
+    /** Explicit include list (empty means include all) */
+    TArray<FString> IncludeList;
+
+    /** Explicit exclude list */
+    TArray<FString> ExcludeList;
+
+    /** Whether to exclude Widget Blueprints */
+    bool bExcludeWidgets = false;
+
+    /** Whether to exclude Animation Blueprints */
+    bool bExcludeAnimBP = false;
+
+    /** Counter for pending async LLM requests */
+    FThreadSafeCounter PendingRequests;
+
+    /** Counter for successful translations */
+    FThreadSafeCounter SuccessCount;
+
+    /** Counter for failed translations */
+    FThreadSafeCounter FailureCount;
+
+    /** API key for LLM provider */
+    FString ApiKey;
+
+    /** Make HTTP request via curl subprocess (workaround for commandlet SSL issues) */
+    FString CallCurlForLLMRequest(const FString& JsonPayload, const FString& SystemPrompt);
+
+    /** Save translation result to disk */
+    void SaveTranslationResult(const FString& BlueprintName, const FString& GraphName, const FString& Response);
+};
+
+#endif // WITH_EDITOR

--- a/Source/Public/Core/N2CEditorIntegration.h
+++ b/Source/Public/Core/N2CEditorIntegration.h
@@ -57,6 +57,9 @@ private:
     /** Execute copy blueprint JSON to clipboard for a specific editor */
     void ExecuteCopyJsonForEditor(TWeakPtr<FBlueprintEditor> InEditor);
     
+    /** Execute translate entire blueprint (all graphs) for a specific editor */
+    void ExecuteTranslateEntireBlueprintForEditor(TWeakPtr<FBlueprintEditor> InEditor);
+    
     /** Handle asset editor opened callback */
     void HandleAssetEditorOpened(UObject* Asset, IAssetEditorInstance* EditorInstance);
 

--- a/Source/Public/Core/N2CNodeCollector.h
+++ b/Source/Public/Core/N2CNodeCollector.h
@@ -15,7 +15,7 @@
  * Interfaces with the active Blueprint Editor instance to gather live nodes,
  * maintaining direct access to node properties and relationships.
  */
-class FN2CNodeCollector
+class NODETOCODE_API FN2CNodeCollector
 {
 public:
     /** Get the singleton instance */

--- a/Source/Public/Core/N2CNodeTranslator.h
+++ b/Source/Public/Core/N2CNodeTranslator.h
@@ -29,6 +29,9 @@ public:
      */
     bool GenerateN2CStruct(const TArray<UK2Node*>& CollectedNodes);
 
+    /** Generate N2CBlueprint from entire Blueprint (all graphs, optional variables) */
+    bool GenerateFromBlueprint(class UBlueprint* InBlueprint, bool bIncludeVariables = true);
+
     /**
      * @brief Get the generated Blueprint structure
      * @return The translated Blueprint structure
@@ -150,4 +153,13 @@ private:
 
     /** Log detailed debug information about the node */
     void LogNodeDetails(const FN2CNodeDefinition& NodeDef);
+
+    /** Collect Blueprint component instances and their overridden default properties */
+    void CollectComponentOverrides(class UBlueprint* InBlueprint);
+
+    /** Convert FBPVariableDescription to FN2CVariable */
+    void ConvertVariableDescription(const struct FBPVariableDescription& Desc, struct FN2CVariable& OutVar);
+
+    /** Collect local variables from a function entry node */
+    void CollectLocalVariables(class UK2Node_FunctionEntry* EntryNode, TArray<struct FN2CVariable>& OutVariables);
 };

--- a/Source/Public/Core/N2CNodeTranslator.h
+++ b/Source/Public/Core/N2CNodeTranslator.h
@@ -16,7 +16,7 @@
  * Takes raw Blueprint nodes collected from the editor and translates them
  * into the structured FN2CBlueprint format for further processing.
  */
-class FN2CNodeTranslator
+class NODETOCODE_API FN2CNodeTranslator
 {
 public:
     /** Get the singleton instance */

--- a/Source/Public/Core/N2CSerializer.h
+++ b/Source/Public/Core/N2CSerializer.h
@@ -37,6 +37,7 @@ private:
     static TSharedPtr<FJsonObject> FlowsToJsonObject(const FN2CFlows& Flows);
     static TSharedPtr<FJsonObject> StructToJsonObject(const FN2CStruct& Struct);
     static TSharedPtr<FJsonObject> EnumToJsonObject(const FN2CEnum& Enum);
+    static TSharedPtr<FJsonObject> VariableToJsonObject(const FN2CVariable& Var);
 
     /** JSON parsing helpers */
     static bool ParseBlueprintFromJson(const TSharedPtr<FJsonObject>& JsonObject, FN2CBlueprint& OutBlueprint);
@@ -46,6 +47,7 @@ private:
     static bool ParseFlowsFromJson(const TSharedPtr<FJsonObject>& JsonObject, FN2CFlows& OutFlows);
     static bool ParseStructFromJson(const TSharedPtr<FJsonObject>& JsonObject, FN2CStruct& OutStruct);
     static bool ParseEnumFromJson(const TSharedPtr<FJsonObject>& JsonObject, FN2CEnum& OutEnum);
+    static bool ParseVariableFromJson(const TSharedPtr<FJsonObject>& JsonObject, FN2CVariable& OutVar);
 
     /** Formatting configuration */
     static bool bPrettyPrint;

--- a/Source/Public/Core/N2CSerializer.h
+++ b/Source/Public/Core/N2CSerializer.h
@@ -15,7 +15,7 @@
  * Provides functionality to convert FN2CBlueprint instances and their
  * contained structures into properly formatted JSON output.
  */
-class FN2CSerializer
+class NODETOCODE_API FN2CSerializer
 {
 public:
     /** Convert an FN2CBlueprint to JSON string */

--- a/Source/Public/Core/N2CSettings.h
+++ b/Source/Public/Core/N2CSettings.h
@@ -471,6 +471,11 @@ public:
     UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Node to Code | Code Generation",
         meta=(DisplayName="Max Translation Depth", ClampMin="0", ClampMax="5", UIMin="0", UIMax="5"))
     int32 TranslationDepth = 0;
+
+    /** Include Blueprint variables in serialization output */
+    UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Node to Code | Code Generation",
+        meta=(DisplayName="Include Variables"))
+    bool bIncludeVariables = true;
     
     /** Minimum severity level for logging */
     UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Node to Code | Logging")

--- a/Source/Public/Core/N2CToolbarCommand.h
+++ b/Source/Public/Core/N2CToolbarCommand.h
@@ -17,15 +17,19 @@ public:
     TSharedPtr<FUICommandInfo> OpenWindowCommand;
     TSharedPtr<FUICommandInfo> CollectNodesCommand;
     TSharedPtr<FUICommandInfo> CopyJsonCommand;
+    TSharedPtr<FUICommandInfo> TranslateEntireBlueprintCommand;
 
     // Command names and labels
     static const FName CommandName_Open;
     static const FName CommandName_Collect;
     static const FName CommandName_CopyJson;
+    static const FName CommandName_TranslateEntire;
     static const FText CommandLabel_Open;
     static const FText CommandLabel_Collect;
     static const FText CommandLabel_CopyJson;
+    static const FText CommandLabel_TranslateEntire;
     static const FText CommandTooltip_Open;
     static const FText CommandTooltip_Collect;
     static const FText CommandTooltip_CopyJson;
+    static const FText CommandTooltip_TranslateEntire;
 };

--- a/Source/Public/LLM/N2CLLMModule.h
+++ b/Source/Public/LLM/N2CLLMModule.h
@@ -71,6 +71,12 @@ public:
     /** Save translation files to disk */
     bool SaveTranslationToDisk(const FN2CTranslationResponse& Response, const FN2CBlueprint& Blueprint);
 
+    /** Begin a batch translation (e.g. Translate Entire Blueprint) - all translations in this batch will share the same root directory */
+    void BeginBatchTranslation(const FString& BlueprintName);
+
+    /** End a batch translation - clears the batch root path */
+    void EndBatchTranslation();
+
 private:
     /** Generate file paths for translation */
     FString GenerateTranslationRootPath(const FString& BlueprintName) const;
@@ -83,6 +89,18 @@ private:
     
     /** Create directory if it doesn't exist */
     bool EnsureDirectoryExists(const FString& DirectoryPath) const;
+
+    /** Save graph files with batch-specific features (sanitized names, ClassItSelf special handling) */
+    void SaveGraphFilesWithBatchFeatures(
+        const FN2CTranslationResponse& Response,
+        const FString& RootPath,
+        EN2CCodeLanguage TargetLanguage) const;
+
+    /** Save graph files using original simple logic (for single translations) */
+    void SaveGraphFilesOriginal(
+        const FN2CTranslationResponse& Response,
+        const FString& RootPath,
+        EN2CCodeLanguage TargetLanguage) const;
     
     /** Initialize components */
     bool InitializeComponents();
@@ -119,6 +137,9 @@ private:
     /** Path to the latest translation */
     UPROPERTY()
     FString LatestTranslationPath;
+    
+    /** Cached root path for the current translation batch (e.g. one Translate Entire Blueprint run) */
+    FString CurrentBatchRootPath;
     
     /** Initialization state */
     bool bIsInitialized;

--- a/Source/Public/Models/N2CBlueprint.h
+++ b/Source/Public/Models/N2CBlueprint.h
@@ -213,6 +213,98 @@ struct FN2CStruct
 };
 
 /**
+ * @struct FN2CVariable
+ * @brief Represents a Blueprint variable declaration
+ */
+USTRUCT(BlueprintType)
+struct FN2CVariable
+{
+    GENERATED_BODY()
+
+    /** Variable name */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Node to Code")
+    FString Name;
+
+    /** Variable type (basic category) */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Node to Code")
+    EN2CStructMemberType Type;
+
+    /** Full type name for objects/structs/enums/classes */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Node to Code")
+    FString TypeName;
+
+    /** Container flags */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Node to Code")
+    bool bIsArray = false;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Node to Code")
+    bool bIsSet = false;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Node to Code")
+    bool bIsMap = false;
+
+    /** Map key type if this variable is a Map */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Node to Code")
+    EN2CStructMemberType KeyType;
+
+    /** Map key type name for complex keys */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Node to Code")
+    FString KeyTypeName;
+
+    /** Default value as string (best-effort) */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Node to Code")
+    FString DefaultValue;
+
+    /** Optional comment/tooltip */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Node to Code")
+    FString Comment;
+
+    FN2CVariable()
+        : Name(TEXT(""))
+        , Type(EN2CStructMemberType::Int)
+        , TypeName(TEXT(""))
+        , KeyType(EN2CStructMemberType::Int)
+        , KeyTypeName(TEXT(""))
+        , DefaultValue(TEXT(""))
+        , Comment(TEXT(""))
+    {
+    }
+};
+
+/**
+ * @struct FN2CComponentOverride
+ * @brief Represents a Blueprint component instance and its overridden default properties
+ */
+USTRUCT(BlueprintType)
+struct FN2CComponentOverride
+{
+    GENERATED_BODY()
+
+    /** Component instance name on the Blueprint (variable name on the actor) */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Node to Code")
+    FString ComponentName;
+
+    /** Component class name (e.g. StaticMeshComponent) */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Node to Code")
+    FString ComponentClassName;
+
+    /** Optional attach parent component/variable name */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Node to Code")
+    FString AttachParentName;
+
+    /** Properties on this component whose defaults were overridden in the Blueprint */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Node to Code")
+    TArray<FN2CVariable> OverriddenProperties;
+
+    FN2CComponentOverride()
+        : ComponentName(TEXT(""))
+        , ComponentClassName(TEXT(""))
+        , AttachParentName(TEXT(""))
+    {
+    }
+};
+
+/**
  * @struct FN2CEnumValue
  * @brief Represents a single value in an enum
  */
@@ -286,6 +378,8 @@ enum class EN2CGraphType : uint8
     Construction    UMETA(DisplayName = "Construction Script"),
     /** An animation graph */
     Animation      UMETA(DisplayName = "Animation"),
+    /** A synthetic class skeleton graph (no nodes, only class-level structure) */
+    ClassItSelf  UMETA(DisplayName = "Class Skeleton"),
     /** A struct definition */
     Struct         UMETA(DisplayName = "Struct"),
     /** An enum definition */
@@ -316,6 +410,10 @@ struct FN2CGraph
     /** Execution and data flow connections for this graph */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Node to Code")
     FN2CFlows Flows;
+
+    /** Local variables declared for this graph (e.g. function-local variables) */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Node to Code")
+    TArray<FN2CVariable> LocalVariables;
 
     FN2CGraph()
         : GraphType(EN2CGraphType::EventGraph)
@@ -354,6 +452,14 @@ struct FN2CBlueprint
     /** Array of all enums used in the Blueprint */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Node to Code")
     TArray<FN2CEnum> Enums;
+
+    /** Array of declared Blueprint variables */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Node to Code")
+    TArray<FN2CVariable> Variables;
+
+    /** Array of Blueprint components and their overridden default properties */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Node to Code")
+    TArray<FN2CComponentOverride> Components;
 
     FN2CBlueprint()
     {

--- a/Source/Public/Models/N2CBlueprint.h
+++ b/Source/Public/Models/N2CBlueprint.h
@@ -209,7 +209,7 @@ struct FN2CStruct
     }
 
     /** Validates the struct definition */
-    bool IsValid() const;
+    NODETOCODE_API bool IsValid() const;
 };
 
 /**
@@ -356,7 +356,7 @@ struct FN2CEnum
     }
 
     /** Validates the enum definition */
-    bool IsValid() const;
+    NODETOCODE_API bool IsValid() const;
 };
 
 /**
@@ -421,7 +421,7 @@ struct FN2CGraph
     }
 
     /** Validates the graph structure */
-    bool IsValid() const;
+    NODETOCODE_API bool IsValid() const;
 };
 
 /**
@@ -467,5 +467,5 @@ struct FN2CBlueprint
     }
 
     /** Validates the Blueprint structure and its enums */
-    bool IsValid() const;
+    NODETOCODE_API bool IsValid() const;
 };


### PR DESCRIPTION
## Summary

- Add `UN2CBatchBlueprintCommandlet` for batch-converting Blueprints to C++ from the command line
- Export core classes (`FN2CNodeTranslator`, `FN2CNodeCollector`, `FN2CSerializer`) with `NODETOCODE_API` for external module usage
- Fix `ProcessN2CJson` to invoke `OnComplete` callback in all code paths
- Add `AssetRegistry` module dependency

## Batch Commandlet Features

Enables automated Blueprint-to-C++ conversion without requiring the editor UI:

```
UnrealEditor-Cmd.exe Project.uproject -run=N2CBatchBlueprint [options]
```

**Options:**
- `-DryRun` - List Blueprints without converting
- `-Path=/Game/...` - Root path to search (default: /Game/)
- `-Include=BP1,BP2` - Only convert these Blueprints
- `-Exclude=BP1,BP2` - Skip these Blueprints  
- `-ExcludeWidgets` - Skip Widget Blueprints (WBP_* or UserWidget parents)
- `-ExcludeAnimBP` - Skip Animation Blueprints (ABP_* or AnimInstance parents)

**Environment:**
- `ANTHROPIC_API_KEY` env var or NodeToCode secrets file

**Output:**
- `Saved/NodeToCode/Translations/<BlueprintName>/<GraphName>.txt`

## Technical Notes

Uses curl subprocess for LLM API calls as a workaround for SSL/HTTP issues in commandlet mode (Unreal's HTTP module has issues outside the main editor process).

## Test plan

- [ ] Build plugin with UE 5.4
- [ ] Run commandlet with `-DryRun` to verify Blueprint discovery
- [ ] Run full conversion on a test Blueprint
- [ ] Verify output files are created correctly

🤖 Generated with [Claude Code](https://claude.ai/code)