### PR TITLE
fix: Replace raw UObject* UPROPERTY members with TObjectPtr for UHT compliance

### DIFF
--- a/Source/Public/Core/N2CSettings.h
+++ b/Source/Public/Core/N2CSettings.h
@@ -383,7 +383,7 @@ public:
 
     /** Reference to user secrets containing API keys */
     UPROPERTY(Transient)
-    mutable UN2CUserSecrets* UserSecrets;
+    mutable TObjectPtr<UN2CUserSecrets> UserSecrets;
 
     /** Anthropic Model Selection - Sonnet 3.5 or 3.7 recommended*/
     UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Node to Code | LLM Services | Anthropic")

--- a/Source/Public/LLM/N2CBaseLLMService.h
+++ b/Source/Public/LLM/N2CBaseLLMService.h
@@ -48,13 +48,13 @@ protected:
     FN2CLLMConfig Config;
     
     UPROPERTY()
-    UN2CHttpHandlerBase* HttpHandler;
-    
+    TObjectPtr<UN2CHttpHandlerBase> HttpHandler;
+
     UPROPERTY()
-    UN2CResponseParserBase* ResponseParser;
-    
+    TObjectPtr<UN2CResponseParserBase> ResponseParser;
+
     UPROPERTY()
-    UN2CSystemPromptManager* PromptManager;
+    TObjectPtr<UN2CSystemPromptManager> PromptManager;
     
     bool bIsInitialized;
 };

--- a/Source/Public/LLM/N2CLLMModule.h
+++ b/Source/Public/LLM/N2CLLMModule.h
@@ -99,15 +99,15 @@ private:
 
     /** System prompt manager */
     UPROPERTY()
-    class UN2CSystemPromptManager* PromptManager;
+    TObjectPtr<class UN2CSystemPromptManager> PromptManager;
 
     /** HTTP handler */
     UPROPERTY()
-    class UN2CHttpHandlerBase* HttpHandler;
+    TObjectPtr<class UN2CHttpHandlerBase> HttpHandler;
 
     /** Response parser */
     UPROPERTY()
-    class UN2CResponseParserBase* ResponseParser;
+    TObjectPtr<class UN2CResponseParserBase> ResponseParser;
 
     /** Active LLM service */
     TScriptInterface<class IN2CLLMService> ActiveService;


### PR DESCRIPTION
## Summary
- Replaces 7 raw `UObject*` UPROPERTY member pointers with `TObjectPtr<>` across 3 header files
- Fixes compilation failure in projects with strict UHT settings (`NonEngineNativePointerMemberBehavior=Disallow`)
- This is the default configuration in Lyra and other Epic sample projects on UE 5.4+

## Problem
Projects using `NativePointerMemberBehavior=Disallow` in their UHT settings fail to compile NodeToCode with errors like:
```
N2CBaseLLMService.h(51): Error: Native pointer usage in member declaration detected [[[UN2CHttpHandlerBase*]]].
This is disallowed for the target/module, consider TObjectPtr as an alternative.
```

## Changes
| File | Members Changed |
|------|----------------|
| `N2CBaseLLMService.h` | `HttpHandler`, `ResponseParser`, `PromptManager` |
| `N2CSettings.h` | `UserSecrets` |
| `N2CLLMModule.h` | `PromptManager`, `HttpHandler`, `ResponseParser` |

## Notes
`TObjectPtr<>` is a drop-in replacement for raw `UObject*` in UPROPERTY members — it's implicitly convertible and has no behavioral differences at runtime. This change is fully backwards compatible with UE 5.1+.