### PR TITLE
fix: TObjectPtr UHT compliance + add Gemini 3.x model options

### DIFF
--- a/Source/Private/LLM/N2CLLMModels.cpp
+++ b/Source/Private/LLM/N2CLLMModels.cpp
@@ -14,6 +14,12 @@ const TMap<EN2COpenAIModel, FN2COpenAIPricing> FN2CLLMModelUtils::OpenAIPricing 
 };
 
 const TMap<EN2CGeminiModel, FN2CGeminiPricing> FN2CLLMModelUtils::GeminiPricing = {
+    {EN2CGeminiModel::Gemini_3_1_Pro, FN2CGeminiPricing(0.0f, 0.0f)},
+    {EN2CGeminiModel::Gemini_3_Flash, FN2CGeminiPricing(0.0f, 0.0f)},
+    {EN2CGeminiModel::Gemini_3_1_FlashLite, FN2CGeminiPricing(0.0f, 0.0f)},
+    {EN2CGeminiModel::Gemini_2_5_Pro, FN2CGeminiPricing(0.0f, 0.0f)},
+    {EN2CGeminiModel::Gemini_2_5_Flash, FN2CGeminiPricing(0.0f, 0.0f)},
+    {EN2CGeminiModel::Gemini_2_5_FlashLite, FN2CGeminiPricing(0.0f, 0.0f)},
     {EN2CGeminiModel::Gemini_2_5_ProExp, FN2CGeminiPricing(0.0f, 0.0f)},
     {EN2CGeminiModel::Gemini_Flash_2_0, FN2CGeminiPricing(0.0f, 0.0f)},
     {EN2CGeminiModel::Gemini_Flash_Lite_2_0, FN2CGeminiPricing(0.0f, 0.0f)},
@@ -74,6 +80,18 @@ FString FN2CLLMModelUtils::GetGeminiModelValue(EN2CGeminiModel Model)
 {
     switch (Model)
     {
+    case EN2CGeminiModel::Gemini_3_1_Pro:
+        return TEXT("gemini-3.1-pro-preview");
+    case EN2CGeminiModel::Gemini_3_Flash:
+        return TEXT("gemini-3-flash-preview");
+    case EN2CGeminiModel::Gemini_3_1_FlashLite:
+        return TEXT("gemini-3.1-flash-lite-preview");
+    case EN2CGeminiModel::Gemini_2_5_Pro:
+        return TEXT("gemini-2.5-pro");
+    case EN2CGeminiModel::Gemini_2_5_Flash:
+        return TEXT("gemini-2.5-flash");
+    case EN2CGeminiModel::Gemini_2_5_FlashLite:
+        return TEXT("gemini-2.5-flash-lite");
     case EN2CGeminiModel::Gemini_2_5_ProExp:
         return TEXT("gemini-2.5-pro-exp-03-25");
     case EN2CGeminiModel::Gemini_Flash_2_0:
@@ -89,7 +107,7 @@ FString FN2CLLMModelUtils::GetGeminiModelValue(EN2CGeminiModel Model)
     case EN2CGeminiModel::Gemini_2_0_FlashThinkingExp:
         return TEXT("gemini-2.0-flash-thinking-exp-01-21");
     default:
-        return TEXT("gemini-2.0-flash");
+        return TEXT("gemini-2.5-flash");
     }
 }
 

--- a/Source/Public/Core/N2CSettings.h
+++ b/Source/Public/Core/N2CSettings.h
@@ -383,7 +383,7 @@ public:
 
     /** Reference to user secrets containing API keys */
     UPROPERTY(Transient)
-    mutable UN2CUserSecrets* UserSecrets;
+    mutable TObjectPtr<UN2CUserSecrets> UserSecrets;
 
     /** Anthropic Model Selection - Sonnet 3.5 or 3.7 recommended*/
     UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Node to Code | LLM Services | Anthropic")

--- a/Source/Public/Core/N2CSettings.h
+++ b/Source/Public/Core/N2CSettings.h
@@ -403,9 +403,9 @@ public:
         meta = (DisplayName = "API Key"))
     FString OpenAI_API_Key_UI;
 
-    /** Gemini Model Selection - 2.0 Pro, 2.0 Flash Thinking, or 2.0 Flash recommended */
+    /** Gemini Model Selection - 3 Flash or 2.5 Flash recommended */
     UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Node to Code | LLM Services | Gemini")
-    EN2CGeminiModel Gemini_Model = EN2CGeminiModel::Gemini_2_5_ProExp;
+    EN2CGeminiModel Gemini_Model = EN2CGeminiModel::Gemini_3_Flash;
 
     /** OpenAI API Key - Stored separately in user secrets */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Node to Code | LLM Services | Gemini",

--- a/Source/Public/LLM/N2CBaseLLMService.h
+++ b/Source/Public/LLM/N2CBaseLLMService.h
@@ -48,13 +48,13 @@ protected:
     FN2CLLMConfig Config;
     
     UPROPERTY()
-    UN2CHttpHandlerBase* HttpHandler;
-    
+    TObjectPtr<UN2CHttpHandlerBase> HttpHandler;
+
     UPROPERTY()
-    UN2CResponseParserBase* ResponseParser;
-    
+    TObjectPtr<UN2CResponseParserBase> ResponseParser;
+
     UPROPERTY()
-    UN2CSystemPromptManager* PromptManager;
+    TObjectPtr<UN2CSystemPromptManager> PromptManager;
     
     bool bIsInitialized;
 };

--- a/Source/Public/LLM/N2CLLMModels.h
+++ b/Source/Public/LLM/N2CLLMModels.h
@@ -33,13 +33,19 @@ enum class EN2CAnthropicModel : uint8
 UENUM(BlueprintType)
 enum class EN2CGeminiModel : uint8
 {
-    Gemini_2_5_ProExp            UMETA(DisplayName = "Gemini 2.5 Pro Experimental", Value = "gemini-2.5-pro-exp-03-25"),
-    Gemini_Flash_2_0             UMETA(DisplayName = "Gemini 2.0 Flash", Value = "gemini-2.0-flash"),
-    Gemini_Flash_Lite_2_0        UMETA(DisplayName = "Gemini 2.0 Flash-Lite-Preview-02-05", Value = "gemini-2.0-flash-lite-preview-02-05"),
-    Gemini_1_5_Flash             UMETA(DisplayName = "Gemini 1.5 Flash", Value = "gemini-1.5-flash"),
-    Gemini_1_5_Pro               UMETA(DisplayName = "Gemini 1.5 Pro", Value = "gemini-1.5-pro"),
-    Gemini_2_0_ProExp_02_05      UMETA(DisplayName = "Gemini 2.0 Pro Exp 02-05", Value = "gemini-2.0-pro-exp-02-05"),
-    Gemini_2_0_FlashThinkingExp  UMETA(DisplayName = "Gemini 2.0 Flash Thinking Exp 01-21", Value = "gemini-2.0-flash-thinking-exp-01-21"),
+    Gemini_3_1_Pro               UMETA(DisplayName = "Gemini 3.1 Pro Preview"),
+    Gemini_3_Flash               UMETA(DisplayName = "Gemini 3 Flash Preview"),
+    Gemini_3_1_FlashLite         UMETA(DisplayName = "Gemini 3.1 Flash-Lite Preview"),
+    Gemini_2_5_Pro               UMETA(DisplayName = "Gemini 2.5 Pro"),
+    Gemini_2_5_Flash             UMETA(DisplayName = "Gemini 2.5 Flash"),
+    Gemini_2_5_FlashLite         UMETA(DisplayName = "Gemini 2.5 Flash-Lite"),
+    Gemini_2_5_ProExp            UMETA(DisplayName = "Gemini 2.5 Pro Experimental"),
+    Gemini_Flash_2_0             UMETA(DisplayName = "Gemini 2.0 Flash"),
+    Gemini_Flash_Lite_2_0        UMETA(DisplayName = "Gemini 2.0 Flash-Lite Preview"),
+    Gemini_1_5_Flash             UMETA(DisplayName = "Gemini 1.5 Flash"),
+    Gemini_1_5_Pro               UMETA(DisplayName = "Gemini 1.5 Pro"),
+    Gemini_2_0_ProExp_02_05      UMETA(DisplayName = "Gemini 2.0 Pro Exp 02-05"),
+    Gemini_2_0_FlashThinkingExp  UMETA(DisplayName = "Gemini 2.0 Flash Thinking Exp 01-21"),
 };
 
 /** Available DeepSeek models */

--- a/Source/Public/LLM/N2CLLMModule.h
+++ b/Source/Public/LLM/N2CLLMModule.h
@@ -99,15 +99,15 @@ private:
 
     /** System prompt manager */
     UPROPERTY()
-    class UN2CSystemPromptManager* PromptManager;
+    TObjectPtr<class UN2CSystemPromptManager> PromptManager;
 
     /** HTTP handler */
     UPROPERTY()
-    class UN2CHttpHandlerBase* HttpHandler;
+    TObjectPtr<class UN2CHttpHandlerBase> HttpHandler;
 
     /** Response parser */
     UPROPERTY()
-    class UN2CResponseParserBase* ResponseParser;
+    TObjectPtr<class UN2CResponseParserBase> ResponseParser;
 
     /** Active LLM service */
     TScriptInterface<class IN2CLLMService> ActiveService;


### PR DESCRIPTION
## Summary

NodeToCode fails to compile in Lyra-based projects (and any project using strict UHT pointer settings) due to raw `UObject*` usage in UPROPERTY members. This PR fixes that build error and also adds the latest Gemini 3.x models which were missing from the provider dropdown.

## Problem

Lyra (and other Epic sample projects on UE 5.4+) ship with strict UnrealHeaderTool settings:

```
-ini:Engine:[UnrealHeaderTool]:NonEngineNativePointerMemberBehavior=Disallow
```

This causes NodeToCode to fail at the UHT stage with errors like:

```
N2CBaseLLMService.h(51): Error: Native pointer usage in member declaration detected [[[UN2CHttpHandlerBase*]]].
This is disallowed for the target/module, consider TObjectPtr as an alternative.
```

The plugin cannot be used at all in these projects without this fix.

## Changes

### Fix: TObjectPtr UHT Compliance

Replaced 7 raw `UObject*` UPROPERTY member pointers with `TObjectPtr<>`:

| File | Members Changed |
|------|----------------|
| `N2CBaseLLMService.h` | `HttpHandler`, `ResponseParser`, `PromptManager` |
| `N2CSettings.h` | `UserSecrets` |
| `N2CLLMModule.h` | `PromptManager`, `HttpHandler`, `ResponseParser` |

`TObjectPtr<>` is a drop-in replacement — implicitly convertible, no behavioral differences at runtime. Fully backwards compatible with UE 5.1+.

### Feat: Gemini 3.x and 2.5 Stable Models

Added 6 new Gemini models to the provider dropdown:

| Display Name | API Model ID |
|-------------|-------------|
| Gemini 3.1 Pro Preview | `gemini-3.1-pro-preview` |
| Gemini 3 Flash Preview | `gemini-3-flash-preview` |
| Gemini 3.1 Flash-Lite Preview | `gemini-3.1-flash-lite-preview` |
| Gemini 2.5 Pro | `gemini-2.5-pro` |
| Gemini 2.5 Flash | `gemini-2.5-flash` |
| Gemini 2.5 Flash-Lite | `gemini-2.5-flash-lite` |

Updated default Gemini model from 2.5 Pro Experimental to Gemini 3 Flash Preview. All existing model entries preserved for backwards compatibility.

Model IDs sourced from [Google AI for Developers - Models](https://ai.google.dev/gemini-api/docs/models) as of March 2026.