### PR TITLE
feat: Add MiniMax as LLM provider

### DIFF
--- a/Source/Private/Core/N2CSettings.cpp
+++ b/Source/Private/Core/N2CSettings.cpp
@@ -44,6 +44,7 @@ UN2CSettings::UN2CSettings()
     Anthropic_API_Key_UI = UserSecrets->Anthropic_API_Key;
     Gemini_API_Key_UI = UserSecrets->Gemini_API_Key;
     DeepSeek_API_Key_UI = UserSecrets->DeepSeek_API_Key;
+    MiniMax_API_Key_UI = UserSecrets->MiniMax_API_Key;
     
     // Initialize token estimate
     EstimatedReferenceTokens = GetReferenceFilesTokenEstimate();
@@ -82,6 +83,8 @@ FString UN2CSettings::GetActiveApiKey() const
             return UserSecrets->DeepSeek_API_Key;
         case EN2CLLMProvider::LMStudio:
             return "lm-studio"; // LM Studio just requires a dummy API key for its OpenAI endpoint
+        case EN2CLLMProvider::MiniMax:
+            return UserSecrets->MiniMax_API_Key;
         default:
             return FString();
     }
@@ -103,6 +106,8 @@ FString UN2CSettings::GetActiveModel() const
             return OllamaModel;
         case EN2CLLMProvider::LMStudio:
             return LMStudioModel;
+        case EN2CLLMProvider::MiniMax:
+            return MiniMaxModel;
         default:
             return FString();
     }
@@ -266,6 +271,17 @@ void UN2CSettings::PostEditChangeProperty(FPropertyChangedEvent& PropertyChanged
                 UserSecrets->LoadSecrets();
             }
             UserSecrets->DeepSeek_API_Key = DeepSeek_API_Key_UI;
+            UserSecrets->SaveSecrets();
+            return;
+        }
+        if (PropertyName == GET_MEMBER_NAME_CHECKED(UN2CSettings, MiniMax_API_Key_UI))
+        {
+            if (!UserSecrets)
+            {
+                UserSecrets = NewObject<UN2CUserSecrets>();
+                UserSecrets->LoadSecrets();
+            }
+            UserSecrets->MiniMax_API_Key = MiniMax_API_Key_UI;
             UserSecrets->SaveSecrets();
             return;
         }

--- a/Source/Private/Core/N2CUserSecrets.cpp
+++ b/Source/Private/Core/N2CUserSecrets.cpp
@@ -71,6 +71,7 @@ void UN2CUserSecrets::LoadSecrets()
     Anthropic_API_Key = JsonObject->GetStringField(TEXT("Anthropic_API_Key"));
     Gemini_API_Key = JsonObject->GetStringField(TEXT("Gemini_API_Key"));
     DeepSeek_API_Key = JsonObject->GetStringField(TEXT("DeepSeek_API_Key"));
+    MiniMax_API_Key = JsonObject->GetStringField(TEXT("MiniMax_API_Key"));
     
     FN2CLogger::Get().Log(
         FString::Printf(TEXT("Successfully loaded secrets from: %s"), *SecretsFilePath),
@@ -88,6 +89,7 @@ void UN2CUserSecrets::SaveSecrets()
     JsonObject->SetStringField(TEXT("Anthropic_API_Key"), Anthropic_API_Key);
     JsonObject->SetStringField(TEXT("Gemini_API_Key"), Gemini_API_Key);
     JsonObject->SetStringField(TEXT("DeepSeek_API_Key"), DeepSeek_API_Key);
+    JsonObject->SetStringField(TEXT("MiniMax_API_Key"), MiniMax_API_Key);
     
     // Serialize to string
     FString JsonString;

--- a/Source/Private/LLM/N2CLLMModule.cpp
+++ b/Source/Private/LLM/N2CLLMModule.cpp
@@ -14,6 +14,7 @@
 #include "LLM/Providers/N2CLMStudioService.h"
 #include "LLM/Providers/N2COpenAIService.h"
 #include "LLM/Providers/N2COllamaService.h"
+#include "LLM/Providers/N2CMiniMaxService.h"
 #include "Utils/N2CLogger.h"
 
 UN2CLLMModule* UN2CLLMModule::Get()
@@ -493,6 +494,7 @@ void UN2CLLMModule::InitializeProviderRegistry()
     Registry->RegisterProvider(EN2CLLMProvider::DeepSeek, UN2CDeepSeekService::StaticClass());
     Registry->RegisterProvider(EN2CLLMProvider::Ollama, UN2COllamaService::StaticClass());
     Registry->RegisterProvider(EN2CLLMProvider::LMStudio, UN2CLMStudioService::StaticClass());
+    Registry->RegisterProvider(EN2CLLMProvider::MiniMax, UN2CMiniMaxService::StaticClass());
     
     FN2CLogger::Get().Log(TEXT("Provider registry initialized"), EN2CLogSeverity::Info, TEXT("LLMModule"));
 }

--- a/Source/Private/LLM/N2CLLMPayloadBuilder.cpp
+++ b/Source/Private/LLM/N2CLLMPayloadBuilder.cpp
@@ -427,6 +427,23 @@ void UN2CLLMPayloadBuilder::ConfigureForLMStudio()
     RootObject->SetBoolField(TEXT("stream"), false);
 }
 
+void UN2CLLMPayloadBuilder::ConfigureForMiniMax()
+{
+    ProviderType = EN2CLLMProvider::MiniMax;
+
+    // Clear messages array and recreate it
+    MessagesArray.Empty();
+
+    // MiniMax uses OpenAI-compatible format
+    RootObject->SetBoolField(TEXT("stream"), false);
+
+    // Remove temperature if set - some OpenAI-compatible models don't support it
+    if (RootObject->HasField(TEXT("temperature")))
+    {
+        RootObject->RemoveField(TEXT("temperature"));
+    }
+}
+
 FString UN2CLLMPayloadBuilder::Build()
 {
     // Serialize JSON to string

--- a/Source/Private/LLM/Providers/N2CMiniMaxResponseParser.cpp
+++ b/Source/Private/LLM/Providers/N2CMiniMaxResponseParser.cpp
@@ -1,0 +1,122 @@
+// Copyright (c) 2025 Nick McClure (Protospatial). All Rights Reserved.
+
+#include "LLM/Providers/N2CMiniMaxResponseParser.h"
+#include "Utils/N2CLogger.h"
+#include "Serialization/JsonSerializer.h"
+
+bool UN2CMiniMaxResponseParser::ParseLLMResponse(
+    const FString& InJson,
+    FN2CTranslationResponse& OutResponse)
+{
+    // Parse JSON string
+    TSharedPtr<FJsonObject> JsonObject;
+    TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(InJson);
+
+    if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+    {
+        FN2CLogger::Get().LogError(
+            FString::Printf(TEXT("Failed to parse MiniMax response JSON: %s"), *InJson),
+            TEXT("MiniMaxResponseParser")
+        );
+        return false;
+    }
+
+    // Check for MiniMax error response (OpenAI-compatible format)
+    FString ErrorMessage;
+    if (JsonObject->HasField(TEXT("error")))
+    {
+        if (HandleCommonErrorResponse(JsonObject, TEXT("error"), ErrorMessage))
+        {
+            FN2CLogger::Get().LogError(ErrorMessage, TEXT("MiniMaxResponseParser"));
+        }
+        return false;
+    }
+
+    // Extract message content from OpenAI-compatible format
+    FString MessageContent;
+    if (!ExtractStandardMessageContent(JsonObject, TEXT("choices"), TEXT("message"), TEXT("content"), MessageContent))
+    {
+        FN2CLogger::Get().LogError(TEXT("Failed to extract message content from MiniMax response"), TEXT("MiniMaxResponseParser"));
+        return false;
+    }
+
+    // Extract usage information (OpenAI-compatible format)
+    const TSharedPtr<FJsonObject> UsageObject = JsonObject->GetObjectField(TEXT("usage"));
+    if (UsageObject.IsValid())
+    {
+        int32 PromptTokens = 0;
+        int32 CompletionTokens = 0;
+        UsageObject->TryGetNumberField(TEXT("prompt_tokens"), PromptTokens);
+        UsageObject->TryGetNumberField(TEXT("completion_tokens"), CompletionTokens);
+
+        OutResponse.Usage.InputTokens = PromptTokens;
+        OutResponse.Usage.OutputTokens = CompletionTokens;
+
+        FN2CLogger::Get().Log(
+            FString::Printf(TEXT("MiniMax Token Usage - Input: %d Output: %d"), PromptTokens, CompletionTokens),
+            EN2CLogSeverity::Info,
+            TEXT("MiniMaxResponseParser")
+        );
+    }
+
+    FN2CLogger::Get().Log(
+        FString::Printf(TEXT("MiniMax Response Message Content: %s"), *MessageContent),
+        EN2CLogSeverity::Debug,
+        TEXT("MiniMaxResponseParser")
+    );
+
+    // Parse the extracted content as our expected JSON format
+    // Handle code block wrappers that some LLMs return
+    FString ProcessedContent = MessageContent;
+    ProcessedContent = ProcessedContent.TrimStartAndEnd();
+
+    // Remove <think>...</think> reasoning tags that reasoning models use
+    if (ProcessedContent.StartsWith(TEXT("<think>")))
+    {
+        int32 ThinkEnd = ProcessedContent.Find(TEXT("</think>"));
+        if (ThinkEnd != INDEX_NONE)
+        {
+            ProcessedContent = ProcessedContent.Mid(ThinkEnd + 9);
+        }
+    }
+
+    // Remove markdown code block wrappers if present
+    if (ProcessedContent.StartsWith(TEXT("```json")))
+    {
+        ProcessedContent = ProcessedContent.Mid(7);
+    }
+    else if (ProcessedContent.StartsWith(TEXT("```")))
+    {
+        ProcessedContent = ProcessedContent.Mid(3);
+    }
+
+    if (ProcessedContent.EndsWith(TEXT("```")))
+    {
+        ProcessedContent = ProcessedContent.LeftChop(3);
+    }
+
+    ProcessedContent = ProcessedContent.TrimStartAndEnd();
+
+    // Log first 200 chars to see what we're getting
+    FString First200 = ProcessedContent.Left(200);
+    FN2CLogger::Get().Log(
+        FString::Printf(TEXT("MiniMax Content Preview (first 200): '%s'"), *First200),
+        EN2CLogSeverity::Info,
+        TEXT("MiniMaxResponseParser")
+    );
+
+    // Count braces to debug
+    int32 Opens = 0, Closes = 0;
+    for (const TCHAR& c : ProcessedContent)
+    {
+        if (c == '{') Opens++;
+        else if (c == '}') Closes++;
+    }
+    FN2CLogger::Get().Log(
+        FString::Printf(TEXT("MiniMax Content brace count: { = %d, } = %d"), Opens, Closes),
+        EN2CLogSeverity::Info,
+        TEXT("MiniMaxResponseParser")
+    );
+
+    return Super::ParseLLMResponse(ProcessedContent, OutResponse);
+}

--- a/Source/Private/LLM/Providers/N2CMiniMaxService.cpp
+++ b/Source/Private/LLM/Providers/N2CMiniMaxService.cpp
@@ -1,0 +1,111 @@
+// Copyright (c) 2025 Nick McClure (Protospatial). All Rights Reserved.
+
+#include "LLM/Providers/N2CMiniMaxService.h"
+#include "LLM/Providers/N2CMiniMaxResponseParser.h"
+
+#include "Core/N2CSettings.h"
+#include "LLM/N2CSystemPromptManager.h"
+#include "Utils/N2CLogger.h"
+
+bool UN2CMiniMaxService::Initialize(const FN2CLLMConfig& InConfig)
+{
+    // Create a copy of the input config
+    FN2CLLMConfig UpdatedConfig = InConfig;
+
+    // Load MiniMax-specific settings
+    const UN2CSettings* Settings = GetDefault<UN2CSettings>();
+    if (Settings)
+    {
+        // Use custom endpoint if provided, otherwise use default
+        if (!Settings->MiniMaxEndpoint.IsEmpty())
+        {
+            // Normalize the base URL (remove trailing slash if present)
+            FString BaseUrl = Settings->MiniMaxEndpoint;
+            if (BaseUrl.EndsWith(TEXT("/")))
+            {
+                BaseUrl.RemoveAt(BaseUrl.Len() - 1);
+            }
+
+            // Ensure we have the correct endpoint path for MiniMax (OpenAI-compatible)
+            if (!BaseUrl.EndsWith(TEXT("/v1/chat/completions")))
+            {
+                UpdatedConfig.ApiEndpoint = BaseUrl + TEXT("/v1/chat/completions");
+            }
+            else
+            {
+                UpdatedConfig.ApiEndpoint = BaseUrl;
+            }
+
+            MiniMaxEndpoint = UpdatedConfig.ApiEndpoint;
+
+            FN2CLogger::Get().Log(
+                FString::Printf(TEXT("Using MiniMax endpoint: %s"), *UpdatedConfig.ApiEndpoint),
+                EN2CLogSeverity::Info,
+                TEXT("MiniMaxService")
+            );
+        }
+        else
+        {
+            MiniMaxEndpoint = GetDefaultEndpoint();
+            UpdatedConfig.ApiEndpoint = MiniMaxEndpoint;
+        }
+    }
+
+    // Call base class initialization with the updated config
+    return Super::Initialize(UpdatedConfig);
+}
+
+UN2CResponseParserBase* UN2CMiniMaxService::CreateResponseParser()
+{
+    UN2CMiniMaxResponseParser* Parser = NewObject<UN2CMiniMaxResponseParser>(this);
+    return Parser;
+}
+
+void UN2CMiniMaxService::GetConfiguration(
+    FString& OutEndpoint,
+    FString& OutAuthToken,
+    bool& OutSupportsSystemPrompts)
+{
+    OutEndpoint = Config.ApiEndpoint;
+    OutAuthToken = Config.ApiKey;
+
+    // MiniMax supports system prompts
+    OutSupportsSystemPrompts = true;
+}
+
+void UN2CMiniMaxService::GetProviderHeaders(TMap<FString, FString>& OutHeaders) const
+{
+    OutHeaders.Add(TEXT("Content-Type"), TEXT("application/json"));
+
+    // Add authorization header with MiniMax API key
+    if (!Config.ApiKey.IsEmpty())
+    {
+        OutHeaders.Add(TEXT("Authorization"), FString::Printf(TEXT("Bearer %s"), *Config.ApiKey));
+    }
+}
+
+FString UN2CMiniMaxService::FormatRequestPayload(const FString& UserMessage, const FString& SystemMessage) const
+{
+    // Create and configure payload builder for MiniMax
+    UN2CLLMPayloadBuilder* PayloadBuilder = NewObject<UN2CLLMPayloadBuilder>();
+    PayloadBuilder->Initialize(Config.Model);
+    PayloadBuilder->ConfigureForMiniMax();
+
+    // Try prepending source files to user message
+    FString FinalUserMessage = UserMessage;
+    PromptManager->PrependSourceFilesToUserMessage(FinalUserMessage);
+
+    // Add messages - MiniMax supports system prompts
+    if (!SystemMessage.IsEmpty())
+    {
+        PayloadBuilder->AddSystemMessage(SystemMessage);
+    }
+    PayloadBuilder->AddUserMessage(FinalUserMessage);
+
+    // NOTE: MiniMax may not support json_schema structured output
+    // Commenting out to test if that's causing the failure
+    // PayloadBuilder->SetStructuredOutput(UN2CLLMPayloadBuilder::GetN2CResponseSchema());
+
+    // Build and return the payload
+    return PayloadBuilder->Build();
+}

--- a/Source/Public/Core/N2CSettings.h
+++ b/Source/Public/Core/N2CSettings.h
@@ -445,7 +445,22 @@ public:
         meta=(DisplayName="Prepended Model Command", 
               ToolTip="Text to prepend to user messages (e.g., '/no_think' to disable thinking for reasoning models, or other model-specific commands). This text will appear on first line of each user message."))
     FString LMStudioPrependedModelCommand = "";
-    
+
+    /** MiniMax API Key */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Node to Code | LLM Services | MiniMax",
+        meta = (DisplayName = "API Key"))
+    FString MiniMax_API_Key_UI;
+
+    /** MiniMax endpoint */
+    UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Node to Code | LLM Services | MiniMax",
+        meta = (DisplayName = "Server Endpoint"))
+    FString MiniMaxEndpoint = "https://api.minimax.io";
+
+    /** MiniMax Model */
+    UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Node to Code | LLM Services | MiniMax",
+        meta = (DisplayName = "Model Name"))
+    FString MiniMaxModel = "MiniMax-M2.7";
+
     /** OpenAI Model Pricing */
     UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Node to Code | LLM Services | Pricing | OpenAI", DisplayName = "OpenAI Model Pricing")
     TMap<EN2COpenAIModel, FN2COpenAIPricing> OpenAIModelPricing;

--- a/Source/Public/Core/N2CUserSecrets.h
+++ b/Source/Public/Core/N2CUserSecrets.h
@@ -44,6 +44,10 @@ public:
     /** DeepSeek API Key */
     UPROPERTY(EditAnywhere, Category = "Node to Code | API Keys")
     FString DeepSeek_API_Key;
+
+    /** MiniMax API Key */
+    UPROPERTY(EditAnywhere, Category = "Node to Code | API Keys")
+    FString MiniMax_API_Key;
     
 private:
     /** Ensure the secrets directory exists */

--- a/Source/Public/LLM/N2CLLMPayloadBuilder.h
+++ b/Source/Public/LLM/N2CLLMPayloadBuilder.h
@@ -43,6 +43,7 @@ public:
     void ConfigureForDeepSeek();
     void ConfigureForOllama(const struct FN2COllamaConfig& OllamaConfig);
     void ConfigureForLMStudio();
+    void ConfigureForMiniMax();
     
     /** Generate final payload */
     FString Build();

--- a/Source/Public/LLM/N2CLLMTypes.h
+++ b/Source/Public/LLM/N2CLLMTypes.h
@@ -23,7 +23,8 @@ enum class EN2CLLMProvider : uint8
     Gemini      UMETA(DisplayName = "Gemini"),
     Ollama      UMETA(DisplayName = "Ollama"),
     DeepSeek    UMETA(DisplayName = "DeepSeek"),
-    LMStudio    UMETA(DisplayName = "LM Studio")
+    LMStudio    UMETA(DisplayName = "LM Studio"),
+    MiniMax     UMETA(DisplayName = "MiniMax")
 };
 
 /** Status of the Node to Code system */

--- a/Source/Public/LLM/Providers/N2CMiniMaxResponseParser.h
+++ b/Source/Public/LLM/Providers/N2CMiniMaxResponseParser.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2025 Nick McClure (Protospatial). All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "LLM/N2CResponseParserBase.h"
+#include "N2CMiniMaxResponseParser.generated.h"
+
+/**
+ * @class UN2CMiniMaxResponseParser
+ * @brief Parser for MiniMax Chat Completion API responses
+ *
+ * MiniMax uses OpenAI-compatible response format.
+ */
+UCLASS()
+class NODETOCODE_API UN2CMiniMaxResponseParser : public UN2CResponseParserBase
+{
+    GENERATED_BODY()
+
+public:
+    /** Parse MiniMax-specific JSON response */
+    virtual bool ParseLLMResponse(
+        const FString& InJson,
+        FN2CTranslationResponse& OutResponse) override;
+
+protected:
+    // Using base class implementations for error handling and content extraction
+};

--- a/Source/Public/LLM/Providers/N2CMiniMaxService.h
+++ b/Source/Public/LLM/Providers/N2CMiniMaxService.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2025 Nick McClure (Protospatial). All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "LLM/N2CBaseLLMService.h"
+#include "N2CMiniMaxService.generated.h"
+
+/**
+ * @class UN2CMiniMaxService
+ * @brief Implementation of MiniMax's OpenAI-compatible API integration
+ *
+ * MiniMax provides an OpenAI-compatible REST API. This service supports
+ * custom endpoints and structured output via JSON schema for reliable parsing.
+ */
+UCLASS()
+class NODETOCODE_API UN2CMiniMaxService : public UN2CBaseLLMService
+{
+    GENERATED_BODY()
+
+public:
+    // Override Initialize to handle MiniMax-specific setup
+    virtual bool Initialize(const FN2CLLMConfig& InConfig) override;
+
+    // Provider-specific implementations
+    virtual void GetConfiguration(FString& OutEndpoint, FString& OutAuthToken, bool& OutSupportsSystemPrompts) override;
+    virtual EN2CLLMProvider GetProviderType() const override { return EN2CLLMProvider::MiniMax; }
+    virtual void GetProviderHeaders(TMap<FString, FString>& OutHeaders) const override;
+
+protected:
+    // Provider-specific implementations
+    virtual FString FormatRequestPayload(const FString& UserMessage, const FString& SystemMessage) const override;
+    virtual UN2CResponseParserBase* CreateResponseParser() override;
+    virtual FString GetDefaultEndpoint() const override { return TEXT("https://api.minimax.io"); }
+
+private:
+    /** MiniMax endpoint from settings */
+    FString MiniMaxEndpoint;
+};


### PR DESCRIPTION
## Summary
- Added MiniMax as a new LLM provider option (OpenAI-compatible API)
- Supports custom endpoint, model name, and API key configuration
- Handles reasoning model output (strips <think> tags) for reliable JSON parsing
- Registered via the existing provider registry pattern

## Changes
- **N2CLLMTypes.h**: Added `MiniMax` to `EN2CLLMProvider` enum
- **N2CSettings.h/.cpp**: Added endpoint, model, API key settings
- **N2CUserSecrets.h/.cpp**: Added secure API key storage
- **N2CLLMPayloadBuilder.h/.cpp**: Added `ConfigureForMiniMax()`
- **N2CLLMModule.cpp**: Registered the new provider
- **N2CMiniMaxService.h/.cpp**: HTTP service (new)
- **N2CMiniMaxResponseParser.h/.cpp**: Response parser (new)

## Settings
- Server Endpoint: `https://api.minimax.io`
- Model: `MiniMax-M2.7`